### PR TITLE
Add basic Glamourer IPC

### DIFF
--- a/Glamourer/Api/GlamourerIpc.cs
+++ b/Glamourer/Api/GlamourerIpc.cs
@@ -16,15 +16,16 @@ namespace Glamourer.Api
     {
         public const string LabelProviderGetCharacterCustomization = "Glamourer.GetCharacterCustomization";
         public const string LabelProviderApplyCharacterCustomization = "Glamourer.ApplyCharacterCustomization";
-
+        private readonly ClientState clientState;
         private readonly ObjectTable objectTable;
         private readonly DalamudPluginInterface pi;
 
         internal ICallGateProvider<string>? ProviderGetCharacterCustomization;
         internal ICallGateProvider<string, string, object>? ProviderApplyCharacterCustomization;
 
-        public GlamourerIpc(ObjectTable objectTable, DalamudPluginInterface pi)
+        public GlamourerIpc(ClientState clientState, ObjectTable objectTable, DalamudPluginInterface pi)
         {
+            this.clientState = clientState;
             this.objectTable = objectTable;
             this.pi = pi;
 
@@ -82,7 +83,7 @@ namespace Glamourer.Api
         private string GetCharacterCustomization()
         {
             CharacterSave save = new CharacterSave();
-            save.LoadCharacter((Character)Glamourer.GetPlayer("self")!);
+            save.LoadCharacter(clientState.LocalPlayer!);
             return save.ToBase64();
         }
     }

--- a/Glamourer/Api/GlamourerIpc.cs
+++ b/Glamourer/Api/GlamourerIpc.cs
@@ -5,10 +5,6 @@ using Dalamud.Logging;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Ipc;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Glamourer.Api
 {
@@ -18,16 +14,16 @@ namespace Glamourer.Api
         public const string LabelProviderApplyCharacterCustomization = "Glamourer.ApplyCharacterCustomization";
         private readonly ClientState clientState;
         private readonly ObjectTable objectTable;
-        private readonly DalamudPluginInterface pi;
+        private readonly DalamudPluginInterface pluginInterface;
 
         internal ICallGateProvider<string>? ProviderGetCharacterCustomization;
         internal ICallGateProvider<string, string, object>? ProviderApplyCharacterCustomization;
 
-        public GlamourerIpc(ClientState clientState, ObjectTable objectTable, DalamudPluginInterface pi)
+        public GlamourerIpc(ClientState clientState, ObjectTable objectTable, DalamudPluginInterface pluginInterface)
         {
             this.clientState = clientState;
             this.objectTable = objectTable;
-            this.pi = pi;
+            this.pluginInterface = pluginInterface;
 
             InitializeProviders();
         }
@@ -47,7 +43,7 @@ namespace Glamourer.Api
         {
             try
             {
-                ProviderGetCharacterCustomization = pi.GetIpcProvider<string>(LabelProviderGetCharacterCustomization);
+                ProviderGetCharacterCustomization = pluginInterface.GetIpcProvider<string>(LabelProviderGetCharacterCustomization);
                 ProviderGetCharacterCustomization.RegisterFunc(GetCharacterCustomization);
             }
             catch (Exception ex)
@@ -57,7 +53,7 @@ namespace Glamourer.Api
 
             try
             {
-                ProviderApplyCharacterCustomization = pi.GetIpcProvider<string, string, object>(LabelProviderApplyCharacterCustomization);
+                ProviderApplyCharacterCustomization = pluginInterface.GetIpcProvider<string, string, object>(LabelProviderApplyCharacterCustomization);
                 ProviderApplyCharacterCustomization.RegisterAction((customization, characterName) => ApplyCharacterCustomization(customization, characterName));
             }
             catch (Exception ex)

--- a/Glamourer/Api/GlamourerIpc.cs
+++ b/Glamourer/Api/GlamourerIpc.cs
@@ -1,0 +1,87 @@
+﻿using Dalamud.Game.ClientState;
+using Dalamud.Game.ClientState.Objects;
+using Dalamud.Game.ClientState.Objects.Types;
+using Dalamud.Logging;
+using Dalamud.Plugin;
+using Dalamud.Plugin.Ipc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Glamourer.Api
+{
+    public class GlamourerIpc : IDisposable
+    {
+        public const string LabelProviderGetCharacterCustomization = "Glamourer.GetCharacterCustomization";
+        public const string LabelProviderApplyCharacterCustomization = "Glamourer.ApplyCharacterCustomization";
+
+        private readonly ObjectTable objectTable;
+        private readonly DalamudPluginInterface pi;
+
+        internal ICallGateProvider<string>? ProviderGetCharacterCustomization;
+        internal ICallGateProvider<string, string, object>? ProviderApplyCharacterCustomization;
+
+        public GlamourerIpc(ObjectTable objectTable, DalamudPluginInterface pi)
+        {
+            this.objectTable = objectTable;
+            this.pi = pi;
+
+            InitializeProviders();
+        }
+
+        public void Dispose()
+        {
+            DisposeProviders();
+        }
+
+        private void DisposeProviders()
+        {
+            ProviderApplyCharacterCustomization?.UnregisterFunc();
+            ProviderGetCharacterCustomization?.UnregisterAction();
+        }
+
+        private void InitializeProviders()
+        {
+            try
+            {
+                ProviderGetCharacterCustomization = pi.GetIpcProvider<string>(LabelProviderGetCharacterCustomization);
+                ProviderGetCharacterCustomization.RegisterFunc(GetCharacterCustomization);
+            }
+            catch (Exception ex)
+            {
+                PluginLog.Error(ex, $"Error registering IPC provider for {LabelProviderApplyCharacterCustomization}.");
+            }
+
+            try
+            {
+                ProviderApplyCharacterCustomization = pi.GetIpcProvider<string, string, object>(LabelProviderApplyCharacterCustomization);
+                ProviderApplyCharacterCustomization.RegisterAction((customization, characterName) => ApplyCharacterCustomization(customization, characterName));
+            }
+            catch (Exception ex)
+            {
+                PluginLog.Error(ex, $"Error registering IPC provider for {LabelProviderApplyCharacterCustomization}.");
+            }
+        }
+
+        private void ApplyCharacterCustomization(string customization, string characterName)
+        {
+            var save = CharacterSave.FromString(customization);
+            foreach (var gameObject in objectTable)
+            {
+                if (gameObject.Name.ToString() == characterName)
+                {
+                    save.Apply((Character)gameObject);
+                }
+            }
+        }
+
+        private string GetCharacterCustomization()
+        {
+            CharacterSave save = new CharacterSave();
+            save.LoadCharacter((Character)Glamourer.GetPlayer("self")!);
+            return save.ToBase64();
+        }
+    }
+}

--- a/Glamourer/Api/GlamourerIpc.cs
+++ b/Glamourer/Api/GlamourerIpc.cs
@@ -72,7 +72,9 @@ namespace Glamourer.Api
             {
                 if (gameObject.Name.ToString() == characterName)
                 {
-                    save.Apply((Character)gameObject);
+                    var player = (Character)gameObject;
+                    save.Apply(player);
+                    Glamourer.Penumbra.UpdateCharacters(player, null);
                 }
             }
         }

--- a/Glamourer/Glamourer.cs
+++ b/Glamourer/Glamourer.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Game.Command;
 using Dalamud.Plugin;
+using Glamourer.Api;
 using Glamourer.Customization;
 using Glamourer.Designs;
 using Glamourer.FileSystem;
@@ -27,6 +28,7 @@ namespace Glamourer
         public readonly  DesignManager         Designs;
         public readonly  FixedDesigns          FixedDesigns;
         public static    RevertableDesigns     RevertableDesigns = new();
+        public readonly  GlamourerIpc          GlamourerIpc;
 
 
         public static string         Version  = string.Empty;
@@ -41,6 +43,7 @@ namespace Glamourer
             Designs       = new DesignManager();
             Penumbra      = new PenumbraAttach(Config.AttachToPenumbra);
             PlayerWatcher = PlayerWatchFactory.Create(Dalamud.Framework, Dalamud.ClientState, Dalamud.Objects);
+            GlamourerIpc  = new(Dalamud.Objects, pluginInterface);
             if (!Config.ApplyFixedDesigns)
                 PlayerWatcher.Disable();
 
@@ -61,7 +64,7 @@ namespace Glamourer
         public void OnGlamourer(string command, string arguments)
             => _interface.ToggleVisibility();
 
-        private static GameObject? GetPlayer(string name)
+        public static GameObject? GetPlayer(string name)
         {
             var lowerName = name.ToLowerInvariant();
             return lowerName switch

--- a/Glamourer/Glamourer.cs
+++ b/Glamourer/Glamourer.cs
@@ -43,7 +43,7 @@ namespace Glamourer
             Designs       = new DesignManager();
             Penumbra      = new PenumbraAttach(Config.AttachToPenumbra);
             PlayerWatcher = PlayerWatchFactory.Create(Dalamud.Framework, Dalamud.ClientState, Dalamud.Objects);
-            GlamourerIpc  = new(Dalamud.Objects, pluginInterface);
+            GlamourerIpc  = new GlamourerIpc(Dalamud.ClientState, Dalamud.Objects, Dalamud.PluginInterface);
             if (!Config.ApplyFixedDesigns)
                 PlayerWatcher.Disable();
 
@@ -64,7 +64,7 @@ namespace Glamourer
         public void OnGlamourer(string command, string arguments)
             => _interface.ToggleVisibility();
 
-        public static GameObject? GetPlayer(string name)
+        private static GameObject? GetPlayer(string name)
         {
             var lowerName = name.ToLowerInvariant();
             return lowerName switch

--- a/Glamourer/Glamourer.cs
+++ b/Glamourer/Glamourer.cs
@@ -203,6 +203,7 @@ namespace Glamourer
             Penumbra.Dispose();
             PlayerWatcher.Dispose();
             _interface.Dispose();
+            GlamourerIpc.Dispose();
             Dalamud.Commands.RemoveHandler("/glamour");
             Dalamud.Commands.RemoveHandler("/glamourer");
         }


### PR DESCRIPTION
This adds a basic Glamourer IPC with following functionalities:
- get the current character state as Glamourer encoded base64 string
- apply Glamourer encoded base64 strings to player names