### PR TITLE
Add options to apply dye color to all slots

### DIFF
--- a/Glamourer/Gui/Interface.cs
+++ b/Glamourer/Gui/Interface.cs
@@ -22,6 +22,7 @@ namespace Glamourer.Gui
         private readonly IReadOnlyDictionary<uint, ModelChara>                                  _models;
         private readonly IObjectIdentifier                                                      _identifier;
         private readonly Dictionary<EquipSlot, (ComboWithFilter<Item>, ComboWithFilter<Stain>)> _combos;
+        private readonly ComboWithFilter<Stain>                                                 _globalStainCombo;
         private readonly ImGuiScene.TextureWrap?                                                _legacyTattooIcon;
         private readonly Dictionary<EquipSlot, string>                                          _equipSlotNames;
         private readonly DesignManager                                                          _designs;
@@ -52,6 +53,7 @@ namespace Glamourer.Gui
 
             var equip = GameData.ItemsBySlot(Dalamud.GameData);
             _combos           = equip.ToDictionary(kvp => kvp.Key, kvp => CreateCombos(kvp.Key, kvp.Value, stainCombo));
+            _globalStainCombo = new ComboWithFilter<Stain>("Dye All Slots", stainCombo);
             _legacyTattooIcon = GetLegacyTattooIcon();
         }
 

--- a/Glamourer/Gui/InterfaceEquipment.cs
+++ b/Glamourer/Gui/InterfaceEquipment.cs
@@ -41,6 +41,42 @@ namespace Glamourer.Gui
 
         }
 
+        private bool DrawGlobalStainSelector(ComboWithFilter<Stain> stainCombo)
+        {
+            stainCombo.PostPreview = null;
+
+            var change = stainCombo.Draw(string.Empty, out var newStain);
+            if (!change)
+            {
+                ImGuiCustom.HoverTooltip("Right-click to clear.");
+                if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
+                {
+                    change = true;
+                    newStain = Stain.None;
+                }
+            }
+
+            if (!change)
+                return false;
+
+            if (_player == null)
+            {
+                foreach (var key in GetEquipSlotNames().Keys)
+                {
+                    _selection?.Data.WriteStain(key, newStain.RowIndex);
+                }
+                return _inDesignMode;
+            }
+
+            Glamourer.RevertableDesigns.Add(_player);
+            foreach (var key in GetEquipSlotNames().Keys)
+            {
+                newStain.Write(_player.Address, key);
+            }
+            
+            return true;
+        }
+
         private bool DrawItemSelector(ComboWithFilter<Item> equipCombo, Lumina.Excel.GeneratedSheets.Item item, EquipSlot slot = EquipSlot.Unknown)
         {
             var currentName = item.Name.ToString();
@@ -142,6 +178,7 @@ namespace Glamourer.Gui
             var ret = false;
             if (ImGui.CollapsingHeader("Character Equipment"))
             {
+                ret |= DrawGlobalStainSelector(_globalStainCombo);
                 ret |= DrawWeapon(EquipSlot.MainHand, equip.MainHand);
                 ret |= DrawWeapon(EquipSlot.OffHand,  equip.OffHand);
                 ret |= DrawEquipSlot(EquipSlot.Head,    equip.Head);
@@ -164,6 +201,7 @@ namespace Glamourer.Gui
             var ret = false;
             if (ImGui.CollapsingHeader("Character Equipment"))
             {
+                ret |= DrawGlobalStainSelector(_globalStainCombo);
                 ret |= DrawWeaponWithCheck(EquipSlot.MainHand, equip.MainHand, CharacterEquipMask.MainHand, ref mask);
                 ret |= DrawWeaponWithCheck(EquipSlot.OffHand,  equip.OffHand,  CharacterEquipMask.OffHand,  ref mask);
                 ret |= DrawEquipSlotWithCheck(EquipSlot.Head,    equip.Head,    CharacterEquipMask.Head,    ref mask);


### PR DESCRIPTION
Adds an additional stain combo box above the equipment list that allows a dye color to be selected and applied to all equipment slots simultaneously.