### PR TITLE
Add option to disable the application of fixed designs when in gpose

### DIFF
--- a/Glamourer/Designs/FixedDesigns.cs
+++ b/Glamourer/Designs/FixedDesigns.cs
@@ -124,6 +124,10 @@ namespace Glamourer.Designs
         private void OnPlayerChange(Character character)
         {
             var name = character.Name.ToString();
+
+            if (Dalamud.PluginInterface.UiBuilder.GposeActive && !Glamourer.Config.ApplyInGPose)
+                return;
+
             if (!EnabledDesigns.TryGetValue(name, out var designs))
                 return;
 

--- a/Glamourer/GlamourerConfig.cs
+++ b/Glamourer/GlamourerConfig.cs
@@ -24,6 +24,7 @@ public class GlamourerConfig : IPluginConfiguration
     public bool ShowLocks         { get; set; } = true;
     public bool AttachToPenumbra  { get; set; } = true;
     public bool ApplyFixedDesigns { get; set; } = true;
+    public bool ApplyInGPose      { get; set; } = true;
 
     public uint   CustomizationColor { get; set; } = DefaultCustomizationColor;
     public uint   StateColor         { get; set; } = DefaultStateColor;

--- a/Glamourer/Gui/InterfaceConfig.cs
+++ b/Glamourer/Gui/InterfaceConfig.cs
@@ -101,6 +101,8 @@ internal partial class Interface
                 else
                     Glamourer.PlayerWatcher.Disable();
             });
+        DrawConfigCheckMark("Apply in GPose", "Apply fixed designs to characters when entering into Group Pose", cfg.ApplyInGPose,
+            v => cfg.ApplyInGPose = v);
         DrawFixedDesignGroup();
 
         ImGui.Dummy(Vector2.UnitY * ImGui.GetTextLineHeightWithSpacing() / 2);


### PR DESCRIPTION
Currently when entering to gpose you need to manually disable your fixed designs especially if you have changed your outfit otherwise glamourer will overwrite your appearance.

This adds an toggleable option in the settings to temporarily disable fixed designs while entering into gpose, so that it is able to keep an outfit you have customised for the sake of gposing, while not having to remember to toggle your fixed design before and after gposing.

