### PR TITLE
Disable window sounds in GenericPopupWindow

### DIFF
--- a/Glamourer/Gui/GenericPopupWindow.cs
+++ b/Glamourer/Gui/GenericPopupWindow.cs
@@ -24,6 +24,7 @@ public class GenericPopupWindow : Window
           | ImGuiWindowFlags.NoTitleBar, true)
     {
         _config = config;
+        DisableWindowSounds = true;
         IsOpen  = true;
     }
 


### PR DESCRIPTION
Dalamud added open/close sound effects for plugin windows (Dalamud Settings -> Look & Feel tab) a while back.
Every time the game starts it makes the open window sound, because `GenericPopupWindow` didn't disable them and is opened when plugin loads.
This PR disables the sounds in that window.