### PR TITLE
Consider all actors even if there is a gap

### DIFF
--- a/Glamourer/Interop/ObjectManager.cs
+++ b/Glamourer/Interop/ObjectManager.cs
@@ -54,20 +54,11 @@ public class ObjectManager : IReadOnlyDictionary<ActorIdentifier, ActorData>
         _allWorldIdentifiers.Clear();
         _nonOwnedIdentifiers.Clear();
 
-        for (var i = 0; i < (int)ScreenActor.CutsceneStart; ++i)
+        for (var i = 0; i < (int)ScreenActor.CutsceneEnd; ++i)
         {
             Actor character = _objects.GetObjectAddress(i);
             if (character.Identifier(_actors.AwaitedService, out var identifier))
                 HandleIdentifier(identifier, character);
-        }
-
-        for (var i = (int)ScreenActor.CutsceneStart; i < (int)ScreenActor.CutsceneEnd; ++i)
-        {
-            Actor character = _objects.GetObjectAddress(i);
-            if (!character.Valid)
-                break;
-
-            HandleIdentifier(character.GetIdentifier(_actors.AwaitedService), character);
         }
 
         void AddSpecial(ScreenActor idx, string label)


### PR DESCRIPTION
I'm hoping the way you did this was just an optimization rather than a requirement for some reason.

If there is a gap in the cutscene actors, it stops considering later actors. I'm not sure if this ever occurs naturally, but it can definitely occur with Brio if you delete a cutscene/gpose actor, all later actors in the object table no longer appear in Glamourer even though the engine has no issues with gaps in the object table.