### PR TITLE
Prevent automation using "Clear Advanced Dyes" from clearing materials after a manual application with "Force Redrawing"

### DIFF
--- a/Glamourer/State/StateEditor.cs
+++ b/Glamourer/State/StateEditor.cs
@@ -380,7 +380,7 @@ public class StateEditor(
                     Editor.ChangeMetaState(state, meta, mergedDesign.Design.DesignData.GetMeta(meta), Source(meta), out _, settings.Key);
             }
 
-            if (settings.ResetMaterials || !settings.RespectManual && mergedDesign.ResetAdvancedDyes)
+            if (!settings.RespectManual && (settings.ResetMaterials || mergedDesign.ResetAdvancedDyes))
                 state.Materials.Clear();
 
             foreach (var (key, value) in mergedDesign.Design.Materials)

--- a/Glamourer/State/StateEditor.cs
+++ b/Glamourer/State/StateEditor.cs
@@ -380,7 +380,7 @@ public class StateEditor(
                     Editor.ChangeMetaState(state, meta, mergedDesign.Design.DesignData.GetMeta(meta), Source(meta), out _, settings.Key);
             }
 
-            if (settings.ResetMaterials || mergedDesign.ResetAdvancedDyes)
+            if (settings.ResetMaterials || !settings.RespectManual && mergedDesign.ResetAdvancedDyes)
                 state.Materials.Clear();
 
             foreach (var (key, value) in mergedDesign.Design.Materials)


### PR DESCRIPTION
Context: https://discord.com/channels/884363610640498698/884364510964621353/1295488855671312439

Might or might not be the right way of going about it but it fixes the edge case.