### PR TITLE
New SetMeta API Methods

### DIFF
--- a/Glamourer/Api/ItemsApi.cs
+++ b/Glamourer/Api/ItemsApi.cs
@@ -145,7 +145,10 @@ public class ItemsApi(ApiHelpers helpers, ItemManager itemManager, StateManager 
         // Grab MetaIndices from attached flags, and update the states.
         var indices = metaStates.ToIndices();
         foreach (var index in indices)
+        {
             stateManager.ChangeMetaState(state, index, newValue, ApplySettings.Manual);
+            ApiHelpers.Lock(state, key, flags);
+        }
 
         return GlamourerApiEc.Success;
     }
@@ -173,7 +176,10 @@ public class ItemsApi(ApiHelpers helpers, ItemManager itemManager, StateManager 
             anyUnlocked = true;
             // update all MetaStates for this ActorState
             foreach (var index in indices)
+            {
                 stateManager.ChangeMetaState(state, index, newValue, ApplySettings.Manual);
+                ApiHelpers.Lock(state, key, flags);
+            }
         }
 
         if (!anyFound)

--- a/Glamourer/Api/ItemsApi.cs
+++ b/Glamourer/Api/ItemsApi.cs
@@ -6,7 +6,6 @@ using Glamourer.State;
 using OtterGui.Services;
 using Penumbra.GameData.Enums;
 using Penumbra.GameData.Structs;
-using static OtterGui.ItemSelector<T>;
 
 namespace Glamourer.Api;
 
@@ -128,10 +127,10 @@ public class ItemsApi(ApiHelpers helpers, ItemManager itemManager, StateManager 
         return ApiHelpers.Return(GlamourerApiEc.Success, args);
     }
 
-    public GlamourerApiEc SetMetaState(int objectIndex, bool newValue, uint key, SetMetaFlag metaFlags)
+    public GlamourerApiEc SetMetaState(int objectIndex, SetMetaFlag metaStates, bool newValue, uint key, ApplyFlag flags)
     {
-        var args = ApiHelpers.Args("Index", objectIndex, "Value", newValue, "Key", key, "Flags", metaFlags);
-        if (metaFlags == 0)
+        var args = ApiHelpers.Args("Index", objectIndex, "MetaStates", metaStates, "NewValue", newValue, "Key", key, "ApplyFlags", flags);
+        if (metaStates == 0)
             return ApiHelpers.Return(GlamourerApiEc.InvalidState, args);
 
         if (helpers.FindState(objectIndex) is not { } state)
@@ -144,7 +143,7 @@ public class ItemsApi(ApiHelpers helpers, ItemManager itemManager, StateManager 
             return ApiHelpers.Return(GlamourerApiEc.InvalidKey, args);
 
         // Grab MetaIndices from attached flags, and update the states.
-        var indices = metaFlags.ToIndices();
+        var indices = metaStates.ToIndices();
         foreach (var index in indices)
             stateManager.ChangeMetaState(state, index, newValue, ApplySettings.Manual);
 

--- a/Glamourer/Api/ItemsApi.cs
+++ b/Glamourer/Api/ItemsApi.cs
@@ -127,10 +127,10 @@ public class ItemsApi(ApiHelpers helpers, ItemManager itemManager, StateManager 
         return ApiHelpers.Return(GlamourerApiEc.Success, args);
     }
 
-    public GlamourerApiEc SetMetaState(int objectIndex, SetMetaFlag metaStates, bool newValue, uint key, ApplyFlag flags)
+    public GlamourerApiEc SetMeta(int objectIndex, SetMetaFlag types, bool newValue, uint key, ApplyFlag flags)
     {
-        var args = ApiHelpers.Args("Index", objectIndex, "MetaStates", metaStates, "NewValue", newValue, "Key", key, "ApplyFlags", flags);
-        if (metaStates == 0)
+        var args = ApiHelpers.Args("Index", objectIndex, "Meta Types", types, "NewValue", newValue, "Key", key, "ApplyFlags", flags);
+        if (types == 0)
             return ApiHelpers.Return(GlamourerApiEc.InvalidState, args);
 
         if (helpers.FindState(objectIndex) is not { } state)
@@ -143,7 +143,7 @@ public class ItemsApi(ApiHelpers helpers, ItemManager itemManager, StateManager 
             return ApiHelpers.Return(GlamourerApiEc.InvalidKey, args);
 
         // Grab MetaIndices from attached flags, and update the states.
-        var indices = metaStates.ToIndices();
+        var indices = types.ToIndices();
         foreach (var index in indices)
         {
             stateManager.ChangeMetaState(state, index, newValue, ApplySettings.Manual);
@@ -153,13 +153,13 @@ public class ItemsApi(ApiHelpers helpers, ItemManager itemManager, StateManager 
         return GlamourerApiEc.Success;
     }
 
-    public GlamourerApiEc SetMetaStateName(string playerName, SetMetaFlag metaStates, bool newValue, uint key, ApplyFlag flags)
+    public GlamourerApiEc SetMetaState(string playerName, SetMetaFlag types, bool newValue, uint key, ApplyFlag flags)
     {
-        var args = ApiHelpers.Args("Name", playerName, "MetaStates", metaStates, "NewValue", newValue, "Key", key, "ApplyFlags", flags);
-        if (metaStates == 0)
+        var args = ApiHelpers.Args("Name", playerName, "Meta Types", types, "NewValue", newValue, "Key", key, "ApplyFlags", flags);
+        if (types == 0)
             return ApiHelpers.Return(GlamourerApiEc.ItemInvalid, args);
 
-        var indices = metaStates.ToIndices();
+        var indices = types.ToIndices();
         var anyHuman = false;
         var anyFound = false;
         var anyUnlocked = false;

--- a/Glamourer/Designs/MetaIndex.cs
+++ b/Glamourer/Designs/MetaIndex.cs
@@ -1,4 +1,5 @@
-﻿using Glamourer.State;
+﻿using Glamourer.Api.Enums;
+using Glamourer.State;
 
 namespace Glamourer.Designs;
 
@@ -35,6 +36,16 @@ public static class MetaExtensions
             MetaIndex.VisorState  => MetaFlag.VisorState,
             MetaIndex.WeaponState => MetaFlag.WeaponState,
             _                     => (MetaFlag)byte.MaxValue,
+        };
+
+    public static MetaIndex ToIndex(this SetMetaFlag index)
+        => index switch
+        {
+            SetMetaFlag.Wetness     => MetaIndex.Wetness,
+            SetMetaFlag.HatState    => MetaIndex.HatState,
+            SetMetaFlag.VisorState  => MetaIndex.VisorState,
+            SetMetaFlag.WeaponState => MetaIndex.WeaponState,
+            _                       => (MetaIndex)byte.MaxValue,
         };
 
     public static MetaIndex ToIndex(this MetaFlag index)

--- a/Glamourer/Designs/MetaIndex.cs
+++ b/Glamourer/Designs/MetaIndex.cs
@@ -48,6 +48,19 @@ public static class MetaExtensions
             _                       => (MetaIndex)byte.MaxValue,
         };
 
+    public static IEnumerable<MetaIndex> ToIndices(this SetMetaFlag index)
+    {
+        if (index.HasFlag(SetMetaFlag.Wetness))
+            yield return MetaIndex.Wetness;
+        if (index.HasFlag(SetMetaFlag.HatState))
+            yield return MetaIndex.HatState;
+        if (index.HasFlag(SetMetaFlag.VisorState))
+            yield return MetaIndex.VisorState;
+        if (index.HasFlag(SetMetaFlag.WeaponState))
+            yield return MetaIndex.WeaponState;
+    }
+
+
     public static MetaIndex ToIndex(this MetaFlag index)
         => index switch
         {


### PR DESCRIPTION
Adds `SetMeta` and `SetMetaName`, since we have SetItem, SetBonusItem, and ApplyState with a customize filter, but nothing to independently change the value of an Actors MetaData.

Constructed on a separate branch of my fork this time, like advised, and split my commits up to indicate certain progress points as well to help make things easier to filter through and implement ♥