### PR TITLE
Add "Reset Design" command

### DIFF
--- a/Glamourer/Api/StateApi.cs
+++ b/Glamourer/Api/StateApi.cs
@@ -301,7 +301,7 @@ public sealed class StateApi : IGlamourerApiState, IApiService, IDisposable
     private void RevertToAutomation(Actor actor, ActorState state, uint key, ApplyFlag flags)
     {
         var source = (flags & ApplyFlag.Once) != 0 ? StateSource.IpcManual : StateSource.IpcFixed;
-        _autoDesigns.ReapplyAutomation(actor, state.Identifier, state, true, out var forcedRedraw);
+        _autoDesigns.ReapplyAutomation(actor, state.Identifier, state, true, false, out var forcedRedraw);
         _stateManager.ReapplyAutomationState(actor, state, forcedRedraw, true, source);
         ApiHelpers.Lock(state, key, flags);
     }

--- a/Glamourer/Automation/AutoDesignApplier.cs
+++ b/Glamourer/Automation/AutoDesignApplier.cs
@@ -225,7 +225,7 @@ public sealed class AutoDesignApplier : IDisposable
         _state.ReapplyState(actor, forcedRedraw, StateSource.Fixed);
     }
 
-    public void ReapplyAutomation(Actor actor, ActorIdentifier identifier, ActorState state, bool reset, out bool forcedRedraw)
+    public void ReapplyAutomation(Actor actor, ActorIdentifier identifier, ActorState state, bool reset, bool forcedNew, out bool forcedRedraw)
     {
         forcedRedraw = false;
         if (!_config.EnableAutoDesigns)
@@ -235,7 +235,7 @@ public sealed class AutoDesignApplier : IDisposable
             _state.ResetState(state, StateSource.Game);
 
         if (GetPlayerSet(identifier, out var set))
-            Reduce(actor, state, set, false, false, false, out forcedRedraw);
+            Reduce(actor, state, set, false, false, forcedNew, out forcedRedraw);
     }
 
     public bool Reduce(Actor actor, ActorIdentifier identifier, [NotNullWhen(true)] out ActorState? state)

--- a/Glamourer/Gui/DesignQuickBar.cs
+++ b/Glamourer/Gui/DesignQuickBar.cs
@@ -251,7 +251,7 @@ public sealed class DesignQuickBar : Window, IDisposable
 
         foreach (var actor in data.Objects)
         {
-            _autoDesignApplier.ReapplyAutomation(actor, id, state!, true, out var forcedRedraw);
+            _autoDesignApplier.ReapplyAutomation(actor, id, state!, true, false, out var forcedRedraw);
             _stateManager.ReapplyAutomationState(actor, forcedRedraw, true, StateSource.Manual);
         }
     }
@@ -291,7 +291,7 @@ public sealed class DesignQuickBar : Window, IDisposable
 
         foreach (var actor in data.Objects)
         {
-            _autoDesignApplier.ReapplyAutomation(actor, id, state!, false, out var forcedRedraw);
+            _autoDesignApplier.ReapplyAutomation(actor, id, state!, false, false, out var forcedRedraw);
             _stateManager.ReapplyAutomationState(actor, forcedRedraw, false, StateSource.Manual);
         }
     }

--- a/Glamourer/Gui/Tabs/ActorTab/ActorPanel.cs
+++ b/Glamourer/Gui/Tabs/ActorTab/ActorPanel.cs
@@ -393,7 +393,7 @@ public class ActorPanel
                 "Reapply the current automation state for the character on top of its current state..",
                 !_config.EnableAutoDesigns || _state!.IsLocked))
         {
-            _autoDesignApplier.ReapplyAutomation(_actor, _identifier, _state!, false, out var forcedRedraw);
+            _autoDesignApplier.ReapplyAutomation(_actor, _identifier, _state!, false, false, out var forcedRedraw);
             _stateManager.ReapplyAutomationState(_actor, forcedRedraw, false, StateSource.Manual);
         }
 
@@ -402,7 +402,7 @@ public class ActorPanel
                 "Try to revert the character to the state it would have using automated designs.",
                 !_config.EnableAutoDesigns || _state!.IsLocked))
         {
-            _autoDesignApplier.ReapplyAutomation(_actor, _identifier, _state!, true, out var forcedRedraw);
+            _autoDesignApplier.ReapplyAutomation(_actor, _identifier, _state!, true, false, out var forcedRedraw);
             _stateManager.ReapplyAutomationState(_actor, forcedRedraw, true, StateSource.Manual);
         }
 

--- a/Glamourer/Services/CommandService.cs
+++ b/Glamourer/Services/CommandService.cs
@@ -121,8 +121,9 @@ public class CommandService : IDisposable, IApiService
             "apply"              => Apply(argument),
             "reapply"            => ReapplyState(argument),
             "revert"             => Revert(argument),
-            "reapplyautomation"  => ReapplyAutomation(argument, "reapplyautomation",  false),
-            "reverttoautomation" => ReapplyAutomation(argument, "reverttoautomation", true),
+            "reapplyautomation"  => ReapplyAutomation(argument, "reapplyautomation",  false, false),
+            "reverttoautomation" => ReapplyAutomation(argument, "reverttoautomation", true, false),
+            "resetdesign"        => ReapplyAutomation(argument, "resetdesign", false, true),
             "automation"         => SetAutomation(argument),
             "copy"               => CopyState(argument),
             "save"               => SaveState(argument),
@@ -151,6 +152,8 @@ public class CommandService : IDisposable, IApiService
             "Reapplies the current automation state on top of the characters current state.. Use without arguments for help.").BuiltString);
         _chat.Print(new SeStringBuilder().AddCommand("reverttoautomation",
             "Reverts a given character to its supposed state using automated designs. Use without arguments for help.").BuiltString);
+        _chat.Print(new SeStringBuilder().AddCommand("resetdesign",
+            "Reapplies the current automation and resets the random design. Use without arguments for help.").BuiltString);
         _chat.Print(new SeStringBuilder()
             .AddCommand("copy", "Copy the current state of a character to clipboard. Use without arguments for help.").BuiltString);
         _chat.Print(new SeStringBuilder()
@@ -306,7 +309,7 @@ public class CommandService : IDisposable, IApiService
         return true;
     }
 
-    private bool ReapplyAutomation(string argument, string command, bool revert)
+    private bool ReapplyAutomation(string argument, string command, bool revert, bool forcedNew)
     {
         if (argument.Length == 0)
         {
@@ -328,7 +331,7 @@ public class CommandService : IDisposable, IApiService
             {
                 if (_stateManager.GetOrCreate(identifier, actor, out var state))
                 {
-                    _autoDesignApplier.ReapplyAutomation(actor, identifier, state, revert, out var forcedRedraw);
+                    _autoDesignApplier.ReapplyAutomation(actor, identifier, state, revert, forcedNew, out var forcedRedraw);
                     _stateManager.ReapplyAutomationState(actor, forcedRedraw, revert, StateSource.Manual);
                 }
             }


### PR DESCRIPTION
A new command to reapply automation while resetting the random design regardless of settings.

Use case: I want a button to pick a new random glam, but I don't always want to use the setting that will change my glam every redraw.