### PR TITLE
Correct StateFinalized not invoking in certain areas

### DIFF
--- a/Glamourer/Api/StateApi.cs
+++ b/Glamourer/Api/StateApi.cs
@@ -272,7 +272,7 @@ public sealed class StateApi : IGlamourerApiState, IApiService, IDisposable
         {
             case ApplyFlag.Equipment:                           _stateManager.ResetEquip(state, source, key); break;
             case ApplyFlag.Customization:                       _stateManager.ResetCustomize(state, source, key); break;
-            case ApplyFlag.Equipment | ApplyFlag.Customization: _stateManager.ResetState(state, source, key); break;
+            case ApplyFlag.Equipment | ApplyFlag.Customization: _stateManager.ResetState(state, source, key, true); break;
         }
 
         ApiHelpers.Lock(state, key, flags);

--- a/Glamourer/Services/CommandService.cs
+++ b/Glamourer/Services/CommandService.cs
@@ -407,7 +407,7 @@ public class CommandService : IDisposable, IApiService
         foreach (var identifier in identifiers)
         {
             if (_stateManager.TryGetValue(identifier, out var state))
-                _stateManager.ResetState(state, StateSource.Manual);
+                _stateManager.ResetState(state, StateSource.Manual, isFinal: true);
         }
 
 


### PR DESCRIPTION
2 single line changes to ensure  `StateApi.Revert` and `CommandService.Revert` invoke their Revert methods with `isFinal` set to true, as it is the end of their application state.

RevertToAutomation, ReapplyState, and ReapplyToAutomation all do this already, it seems Revert was overlooked when implementing this originally