### PR TITLE
Add Equipment Bar

### DIFF
--- a/Glamourer/Config/EphemeralConfig.cs
+++ b/Glamourer/Config/EphemeralConfig.cs
@@ -19,6 +19,7 @@ public partial class EphemeralConfig : ISavable, IService
     public bool        ShowDesignQuickBar  { get; set; }
     public bool        LockDesignQuickBar  { get; set; }
     public bool        LockMainWindow      { get; set; }
+    public bool        LockEquipmentBar    { get; set; }
     public MainTabType SelectedMainTab     { get; set; } = MainTabType.Settings;
     public Guid        SelectedQuickDesign { get; set; } = Guid.Empty;
     public int         LastSeenVersion     { get; set; } = GlamourerChangelog.LastChangelogVersion;

--- a/Glamourer/Gui/Equipment/BaseItemCombo.cs
+++ b/Glamourer/Gui/Equipment/BaseItemCombo.cs
@@ -57,6 +57,26 @@ public abstract class BaseItemCombo : FilterComboBase<BaseItemCombo.CacheItem>, 
         return false;
     }
 
+    public bool DrawBehavior(in EquipItem item, out EquipItem newItem, float width)
+    {
+        using var id = Im.Id.Push(Label);
+        CurrentItem   = item;
+        CustomVariant = 0;
+        var ret = DrawBehavior(StringU8.Empty, width, out var cache);
+
+        if (CustomVariant.Id is not 0 && Identify(out newItem))
+            return true;
+
+        if (ret)
+        {
+            newItem = cache.Item;
+            return true;
+        }
+
+        newItem = item;
+        return false;
+    }
+
     protected override void PreDrawList()
     {
         _style.PushY(ImStyleDouble.ItemSpacing, 0)

--- a/Glamourer/Gui/Equipment/EquipmentDrawer.cs
+++ b/Glamourer/Gui/Equipment/EquipmentDrawer.cs
@@ -62,12 +62,14 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
     }
 
     private Vector2 _iconSize;
+    private Vector2 _smallIconSize;
     private float   _comboLength;
     private Rgba32  _advancedMaterialColor;
 
     public void Prepare()
     {
         _iconSize              = new Vector2(2 * Im.Style.FrameHeight + Im.Style.ItemSpacing.Y);
+        _smallIconSize         = new Vector2(Im.Style.FrameHeight);
         _comboLength           = DefaultWidth * Im.Style.GlobalScale;
         _advancedMaterialColor = ColorId.AdvancedDyeActive.Value();
         _dragTarget            = EquipSlot.Unknown;
@@ -82,7 +84,7 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
         return changed;
     }
 
-    public void DrawEquip(EquipDrawData equipDrawData)
+    public void DrawEquip(EquipDrawData equipDrawData, bool compact = false)
     {
         if (_config.HideApplyCheckmarks)
             equipDrawData.DisplayApplication = false;
@@ -91,12 +93,12 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
         using var style = ImStyleDouble.ItemSpacing.PushX(Im.Style.ItemInnerSpacing.X);
 
         if (_config.SmallEquip)
-            DrawEquipSmall(equipDrawData);
+            DrawEquipSmall(equipDrawData, compact);
         else
-            DrawEquipNormal(equipDrawData);
+            DrawEquipNormal(equipDrawData, compact);
     }
 
-    public void DrawBonusItem(BonusDrawData bonusDrawData)
+    public void DrawBonusItem(BonusDrawData bonusDrawData, bool compact = false)
     {
         if (_config.HideApplyCheckmarks)
             bonusDrawData.DisplayApplication = false;
@@ -105,12 +107,12 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
         using var style = ImStyleDouble.ItemSpacing.PushX(Im.Style.ItemInnerSpacing.X);
 
         if (_config.SmallEquip)
-            DrawBonusItemSmall(bonusDrawData);
+            DrawBonusItemSmall(bonusDrawData, compact);
         else
-            DrawBonusItemNormal(bonusDrawData);
+            DrawBonusItemNormal(bonusDrawData, compact);
     }
 
-    public void DrawWeapons(EquipDrawData mainhand, EquipDrawData offhand, bool allWeapons)
+    public void DrawWeapons(EquipDrawData mainhand, EquipDrawData offhand, bool allWeapons, bool compact = false)
     {
         if (mainhand.CurrentItem.PrimaryId.Id is 0 && !allWeapons)
             return;
@@ -125,9 +127,9 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
         using var style = ImStyleDouble.ItemSpacing.PushX(Im.Style.ItemInnerSpacing.X);
 
         if (_config.SmallEquip)
-            DrawWeaponsSmall(mainhand, offhand, allWeapons);
+            DrawWeaponsSmall(mainhand, offhand, allWeapons, compact);
         else
-            DrawWeaponsNormal(mainhand, offhand, allWeapons);
+            DrawWeaponsNormal(mainhand, offhand, allWeapons, compact);
     }
 
     public static void DrawMetaToggle(in ToggleDrawData data)
@@ -178,11 +180,20 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
 
     #region Small
 
-    private void DrawEquipSmall(in EquipDrawData equipDrawData)
+    private void DrawEquipSmall(in EquipDrawData equipDrawData, bool compact)
     {
-        DrawStain(equipDrawData, true);
+        DrawStain(equipDrawData, true, compact);
         Im.Line.Same();
-        DrawItem(equipDrawData, out var label, true, false, false);
+        var right = false;
+        var left  = false;
+        if (compact)
+        {
+            equipDrawData.CurrentItem.DrawIcon(_textures, _smallIconSize, equipDrawData.Slot);
+            right = Im.Item.RightClicked();
+            left  = Im.InvisibleButton("###equip"u8, Im.Item.Bounds);
+        }
+
+        DrawItem(equipDrawData, out var label, true, compact, right, left);
         if (equipDrawData.DisplayApplication)
         {
             Im.Line.Same();
@@ -192,21 +203,32 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
         }
         else if (equipDrawData.IsState)
         {
-            _advancedDyes.DrawButton(equipDrawData.Slot, equipDrawData.HasAdvancedDyes ? _advancedMaterialColor : ColorParameter.Default);
+            _advancedDyes.DrawButton(equipDrawData.Slot, equipDrawData.HasAdvancedDyes ? _advancedMaterialColor : ColorParameter.Default,
+                false);
         }
 
         if (VerifyRestrictedGear(equipDrawData))
             label += " (Restricted)"u8;
 
-        DrawEquipLabel(equipDrawData is { IsDesign: true, HasAdvancedDyes: true }, label, equipDrawData);
+        if (!compact)
+            DrawEquipLabel(equipDrawData is { IsDesign: true, HasAdvancedDyes: true }, label, equipDrawData);
     }
 
-    private void DrawBonusItemSmall(in BonusDrawData bonusDrawData)
+    private void DrawBonusItemSmall(in BonusDrawData bonusDrawData, bool compact)
     {
         Im.Dummy(new Vector2(StainId.NumStains * Im.Style.FrameHeight + (StainId.NumStains - 1) * Im.Style.ItemSpacing.X,
             Im.Style.FrameHeight));
         Im.Line.Same();
-        DrawBonusItem(bonusDrawData, out var label, true, false, false);
+        var right = false;
+        var left  = false;
+        if (compact)
+        {
+            bonusDrawData.CurrentItem.DrawIcon(_textures, _smallIconSize, bonusDrawData.Slot);
+            right = Im.Item.RightClicked();
+            left  = Im.InvisibleButton("###bonusItem"u8, Im.Item.Bounds);
+        }
+
+        DrawBonusItem(bonusDrawData, out var label, true, compact, right, left);
         if (bonusDrawData.DisplayApplication)
         {
             Im.Line.Same();
@@ -214,17 +236,26 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
         }
         else if (bonusDrawData.IsState)
         {
-            _advancedDyes.DrawButton(bonusDrawData.Slot, bonusDrawData.HasAdvancedDyes ? _advancedMaterialColor : ColorParameter.Default);
+            _advancedDyes.DrawButton(bonusDrawData.Slot, bonusDrawData.HasAdvancedDyes ? _advancedMaterialColor : ColorParameter.Default,
+                false);
         }
 
-        DrawEquipLabel(bonusDrawData is { IsDesign: true, HasAdvancedDyes: true }, label, bonusDrawData);
+        if (!compact)
+            DrawEquipLabel(bonusDrawData is { IsDesign: true, HasAdvancedDyes: true }, label, bonusDrawData);
     }
 
-    private void DrawWeaponsSmall(EquipDrawData mainhand, EquipDrawData offhand, bool allWeapons)
+    private void DrawWeaponsSmall(EquipDrawData mainhand, EquipDrawData offhand, bool allWeapons, bool compact)
     {
-        DrawStain(mainhand, true);
+        DrawStain(mainhand, true, compact);
         Im.Line.Same();
-        DrawMainhand(ref mainhand, ref offhand, out var mainhandLabel, allWeapons, true, false);
+        var left = false;
+        if (compact)
+        {
+            mainhand.CurrentItem.DrawIcon(_textures, _smallIconSize, mainhand.Slot);
+            left = Im.InvisibleButton("###mainhand"u8, Im.Item.Bounds);
+        }
+
+        DrawMainhand(ref mainhand, ref offhand, out var mainhandLabel, allWeapons, true, compact, left);
         if (mainhand.DisplayApplication)
         {
             Im.Line.Same();
@@ -234,20 +265,32 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
         }
         else if (mainhand.IsState)
         {
-            _advancedDyes.DrawButton(EquipSlot.MainHand, mainhand.HasAdvancedDyes ? _advancedMaterialColor : ColorParameter.Default);
+            _advancedDyes.DrawButton(EquipSlot.MainHand, mainhand.HasAdvancedDyes ? _advancedMaterialColor : ColorParameter.Default, false);
         }
 
-        if (allWeapons)
-            mainhandLabel = new StringU8($"{mainhandLabel} ({mainhand.CurrentItem.Type.ToName()})");
-        WeaponHelpMarker(mainhand is { IsDesign: true, HasAdvancedDyes: true }, mainhandLabel, mainhand);
+        if (!compact)
+        {
+            if (allWeapons)
+                mainhandLabel = new StringU8($"{mainhandLabel} ({mainhand.CurrentItem.Type.ToName()})");
+            WeaponHelpMarker(mainhand is { IsDesign: true, HasAdvancedDyes: true }, mainhandLabel, mainhand);
+        }
 
         var validOffhand = mainhand.CurrentItem.Type.ValidOffhand();
         if (validOffhand is FullEquipType.Unknown)
             return;
 
-        DrawStain(offhand, true);
+        DrawStain(offhand, true, compact);
         Im.Line.Same();
-        DrawOffhand(mainhand, validOffhand, offhand, out var offhandLabel, true, false, false);
+        var right = false;
+        left = false;
+        if (compact)
+        {
+            offhand.CurrentItem.DrawIcon(_textures, _smallIconSize, offhand.Slot);
+            right = Im.Item.RightClicked();
+            left  = Im.InvisibleButton("###offhand"u8, Im.Item.Bounds);
+        }
+
+        DrawOffhand(mainhand, validOffhand, offhand, out var offhandLabel, true, compact, right, left);
         if (offhand.DisplayApplication)
         {
             Im.Line.Same();
@@ -257,33 +300,35 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
         }
         else if (offhand.IsState)
         {
-            _advancedDyes.DrawButton(EquipSlot.OffHand, offhand.HasAdvancedDyes ? _advancedMaterialColor : ColorParameter.Default);
+            _advancedDyes.DrawButton(EquipSlot.OffHand, offhand.HasAdvancedDyes ? _advancedMaterialColor : ColorParameter.Default, false);
         }
 
-        WeaponHelpMarker(offhand is { IsDesign: true, HasAdvancedDyes: true }, offhandLabel, offhand);
+        if (!compact)
+            WeaponHelpMarker(offhand is { IsDesign: true, HasAdvancedDyes: true }, offhandLabel, offhand);
     }
 
     #endregion
 
     #region Normal
 
-    private void DrawEquipNormal(in EquipDrawData equipDrawData)
+    private void DrawEquipNormal(in EquipDrawData equipDrawData, bool compact)
     {
         equipDrawData.CurrentItem.DrawIcon(_textures, _iconSize, equipDrawData.Slot);
         var right = Im.Item.RightClicked();
-        var left  = Im.Item.Clicked();
+        var left  = compact ? Im.InvisibleButton("###equip"u8, Im.Item.Bounds) : Im.Item.Clicked();
         Im.Line.Same();
         using var group = Im.Group();
-        DrawItem(equipDrawData, out var label, false, right, left);
+        DrawItem(equipDrawData, out var label, false, compact, right, left);
         if (equipDrawData.DisplayApplication)
         {
             Im.Line.Same();
             DrawApply(equipDrawData);
         }
 
-        DrawEquipLabel(equipDrawData is { IsDesign: true, HasAdvancedDyes: true }, label, equipDrawData);
+        if (!compact)
+            DrawEquipLabel(equipDrawData is { IsDesign: true, HasAdvancedDyes: true }, label, equipDrawData);
 
-        DrawStain(equipDrawData, false);
+        DrawStain(equipDrawData, false, compact);
         if (equipDrawData.DisplayApplication)
         {
             Im.Line.Same();
@@ -291,7 +336,8 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
         }
         else if (equipDrawData.IsState)
         {
-            _advancedDyes.DrawButton(equipDrawData.Slot, equipDrawData.HasAdvancedDyes ? _advancedMaterialColor : ColorParameter.Default);
+            _advancedDyes.DrawButton(equipDrawData.Slot, equipDrawData.HasAdvancedDyes ? _advancedMaterialColor : ColorParameter.Default,
+                compact);
         }
 
         if (VerifyRestrictedGear(equipDrawData))
@@ -301,13 +347,13 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
         }
     }
 
-    private void DrawBonusItemNormal(in BonusDrawData bonusDrawData)
+    private void DrawBonusItemNormal(in BonusDrawData bonusDrawData, bool compact)
     {
         bonusDrawData.CurrentItem.DrawIcon(_textures, _iconSize, bonusDrawData.Slot);
         var right = Im.Item.RightClicked();
-        var left  = Im.Item.Clicked();
+        var left  = compact ? Im.InvisibleButton("###bonusItem"u8, Im.Item.Bounds) : Im.Item.Clicked();
         Im.Line.Same();
-        DrawBonusItem(bonusDrawData, out var label, false, right, left);
+        DrawBonusItem(bonusDrawData, out var label, false, compact, right, left);
         if (bonusDrawData.DisplayApplication)
         {
             Im.Line.Same();
@@ -315,32 +361,35 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
         }
         else if (bonusDrawData.IsState)
         {
-            _advancedDyes.DrawButton(bonusDrawData.Slot, bonusDrawData.HasAdvancedDyes ? _advancedMaterialColor : ColorParameter.Default);
+            _advancedDyes.DrawButton(bonusDrawData.Slot, bonusDrawData.HasAdvancedDyes ? _advancedMaterialColor : ColorParameter.Default,
+                compact);
         }
 
-        DrawEquipLabel(bonusDrawData is { IsDesign: true, HasAdvancedDyes: true }, label, bonusDrawData);
+        if (!compact)
+            DrawEquipLabel(bonusDrawData is { IsDesign: true, HasAdvancedDyes: true }, label, bonusDrawData);
     }
 
-    private void DrawWeaponsNormal(EquipDrawData mainhand, EquipDrawData offhand, bool allWeapons)
+    private void DrawWeaponsNormal(EquipDrawData mainhand, EquipDrawData offhand, bool allWeapons, bool compact)
     {
         using var style = ImStyleDouble.ItemSpacing.PushX(Im.Style.ItemInnerSpacing.X);
 
         mainhand.CurrentItem.DrawIcon(_textures, _iconSize, EquipSlot.MainHand);
-        var left = Im.Item.Clicked();
+        var left = compact ? Im.InvisibleButton("###mainhand"u8, Im.Item.Bounds) : Im.Item.Clicked();
         Im.Line.Same();
         using (Im.Group())
         {
-            DrawMainhand(ref mainhand, ref offhand, out var mainhandLabel, allWeapons, false, left);
+            DrawMainhand(ref mainhand, ref offhand, out var mainhandLabel, allWeapons, false, compact, left);
             if (mainhand.DisplayApplication)
             {
                 Im.Line.Same();
                 DrawApply(mainhand);
             }
 
-            WeaponHelpMarker(mainhand is { IsDesign: true, HasAdvancedDyes: true }, mainhandLabel, mainhand,
-                allWeapons ? new StringU8(mainhand.CurrentItem.Type.ToName()) : null);
+            if (!compact)
+                WeaponHelpMarker(mainhand is { IsDesign: true, HasAdvancedDyes: true }, mainhandLabel, mainhand,
+                    allWeapons ? new StringU8(mainhand.CurrentItem.Type.ToName()) : null);
 
-            DrawStain(mainhand, false);
+            DrawStain(mainhand, false, compact);
             if (mainhand.DisplayApplication)
             {
                 Im.Line.Same();
@@ -348,7 +397,8 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
             }
             else if (mainhand.IsState)
             {
-                _advancedDyes.DrawButton(EquipSlot.MainHand, mainhand.HasAdvancedDyes ? _advancedMaterialColor : ColorParameter.Default);
+                _advancedDyes.DrawButton(EquipSlot.MainHand, mainhand.HasAdvancedDyes ? _advancedMaterialColor : ColorParameter.Default,
+                    compact);
             }
         }
 
@@ -358,20 +408,21 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
 
         offhand.CurrentItem.DrawIcon(_textures, _iconSize, EquipSlot.OffHand);
         var right = Im.Item.RightClicked();
-        left = Im.Item.Clicked();
+        left = compact ? Im.InvisibleButton("###offhand"u8, Im.Item.Bounds) : Im.Item.Clicked();
         Im.Line.Same();
         using (Im.Group())
         {
-            DrawOffhand(mainhand, validOffhand, offhand, out var offhandLabel, false, right, left);
+            DrawOffhand(mainhand, validOffhand, offhand, out var offhandLabel, false, compact, right, left);
             if (offhand.DisplayApplication)
             {
                 Im.Line.Same();
                 DrawApply(offhand);
             }
 
-            WeaponHelpMarker(offhand is { IsDesign: true, HasAdvancedDyes: true }, offhandLabel, offhand);
+            if (!compact)
+                WeaponHelpMarker(offhand is { IsDesign: true, HasAdvancedDyes: true }, offhandLabel, offhand);
 
-            DrawStain(offhand, false);
+            DrawStain(offhand, false, compact);
             if (offhand.DisplayApplication)
             {
                 Im.Line.Same();
@@ -379,12 +430,12 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
             }
             else if (offhand.IsState)
             {
-                _advancedDyes.DrawButton(EquipSlot.OffHand, offhand.HasAdvancedDyes ? _advancedMaterialColor : ColorParameter.Default);
+                _advancedDyes.DrawButton(EquipSlot.OffHand, offhand.HasAdvancedDyes ? _advancedMaterialColor : ColorParameter.Default, compact);
             }
         }
     }
 
-    private void DrawStain(in EquipDrawData data, bool small)
+    private void DrawStain(in EquipDrawData data, bool small, bool compact)
     {
         using var id       = Im.Id.Push((uint)data.Slot);
         using var disabled = Im.Disabled(data.Locked);
@@ -393,7 +444,7 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
         {
             id.Push(index);
             var found = _stainData.TryGetValue(stainId, out var stain);
-            var change = small
+            var change = small || compact
                 ? _stainCombo.Draw("##stain"u8, stain, out var newStain, Im.Style.FrameHeight)
                 : _stainCombo.Draw("##stain"u8, stain, out newStain,     width);
 
@@ -401,7 +452,7 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
             if (!change)
                 DrawStainDragDrop(data, index, stain, found);
 
-            if (index < data.CurrentStains.Count - 1)
+            if (index < data.CurrentStains.Count - 1 && (small || !compact || index != (data.CurrentStains.Count - 1) >> 1))
                 Im.Line.SameInner();
 
             if (change)
@@ -434,7 +485,7 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
         }
     }
 
-    private void DrawItem(in EquipDrawData data, out StringU8 label, bool small, bool clear, bool open)
+    private void DrawItem(in EquipDrawData data, out StringU8 label, bool small, bool compact, bool clear, bool open)
     {
         Debug.Assert(data.Slot.IsEquipment() || data.Slot.IsAccessory(), $"Called {nameof(DrawItem)} on {data.Slot}.");
 
@@ -444,7 +495,9 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
             UiHelpers.OpenCombo(combo.Label);
 
         using var disabled = Im.Disabled(data.Locked);
-        var       change   = combo.Draw(data.CurrentItem, out var newItem, small ? _comboLength - Im.Style.FrameHeight : _comboLength);
+        var change = compact
+            ? combo.DrawBehavior(data.CurrentItem, out var newItem, small ? _comboLength - Im.Style.FrameHeight : _comboLength)
+            : combo.Draw(data.CurrentItem, out newItem, small ? _comboLength - Im.Style.FrameHeight : _comboLength);
         DrawGearDragDrop(data);
         if (change)
             data.SetItem(newItem);
@@ -455,7 +508,7 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
             data.SetItem(item);
     }
 
-    private void DrawBonusItem(in BonusDrawData data, out StringU8 label, bool small, bool clear, bool open)
+    private void DrawBonusItem(in BonusDrawData data, out StringU8 label, bool small, bool compact, bool clear, bool open)
     {
         var combo = _bonusItemCombo[data.Slot.ToIndex()];
         label = combo.Label;
@@ -463,7 +516,9 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
             UiHelpers.OpenCombo(combo.Label);
 
         using var disabled = Im.Disabled(data.Locked);
-        var       change   = combo.Draw(data.CurrentItem, out var newItem, small ? _comboLength - Im.Style.FrameHeight : _comboLength);
+        var change = compact
+            ? combo.DrawBehavior(data.CurrentItem, out var newItem, small ? _comboLength - Im.Style.FrameHeight : _comboLength)
+            : combo.Draw(data.CurrentItem, out newItem, small ? _comboLength - Im.Style.FrameHeight : _comboLength);
         if (Im.Item.Hovered() && Im.Io.KeyControl)
         {
             if (Im.Keyboard.IsPressed(Key.C))
@@ -556,7 +611,7 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
         return clicked && valid;
     }
 
-    private void DrawMainhand(ref EquipDrawData mainhand, ref EquipDrawData offhand, out StringU8 label, bool drawAll, bool small,
+    private void DrawMainhand(ref EquipDrawData mainhand, ref EquipDrawData offhand, out StringU8 label, bool drawAll, bool small, bool compact,
         bool open)
     {
         if (!_weaponCombo.TryGetValue(drawAll ? FullEquipType.Unknown : mainhand.CurrentItem.Type, out var combo))
@@ -573,7 +628,10 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
         {
             if (!mainhand.Locked && open)
                 UiHelpers.OpenCombo(label);
-            if (combo.Draw(mainhand.CurrentItem, out var newItem, small ? _comboLength - Im.Style.FrameHeight : _comboLength))
+            var change = compact
+                ? combo.DrawBehavior(mainhand.CurrentItem, out var newItem, small ? _comboLength - Im.Style.FrameHeight : _comboLength)
+                : combo.Draw(mainhand.CurrentItem, out newItem, small ? _comboLength - Im.Style.FrameHeight : _comboLength);
+            if (change)
                 changedItem = newItem;
             _itemCopy.HandleCopyPaste(mainhand);
             DrawGearDragDrop(mainhand);
@@ -600,7 +658,8 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
                 "The weapon type could not be identified, thus changing it to other weapons of that type is not possible."u8);
     }
 
-    private void DrawOffhand(in EquipDrawData mainhand, FullEquipType validOffhand, in EquipDrawData offhand, out StringU8 label, bool small, bool clear, bool open)
+    private void DrawOffhand(in EquipDrawData mainhand, FullEquipType validOffhand, in EquipDrawData offhand, out StringU8 label, bool small,
+        bool compact, bool clear, bool open)
     {
         if (!_weaponCombo.TryGetValue(validOffhand, out var combo))
         {
@@ -614,7 +673,10 @@ public sealed class EquipmentDrawer : IUiService, IDisposable
         using var disabled = Im.Disabled(locked);
         if (!locked && open)
             UiHelpers.OpenCombo(combo.Label);
-        if (combo.Draw(offhand.CurrentItem, out var newItem, small ? _comboLength - Im.Style.FrameHeight : _comboLength))
+        var change = compact
+            ? combo.DrawBehavior(offhand.CurrentItem, out var newItem, small ? _comboLength - Im.Style.FrameHeight : _comboLength)
+            : combo.Draw(offhand.CurrentItem, out newItem, small ? _comboLength - Im.Style.FrameHeight : _comboLength);
+        if (change)
             offhand.SetItem(newItem);
         _itemCopy.HandleCopyPaste(offhand);
         DrawGearDragDrop(offhand);

--- a/Glamourer/Gui/EquipmentBarWindow.cs
+++ b/Glamourer/Gui/EquipmentBarWindow.cs
@@ -1,0 +1,122 @@
+using Dalamud.Interface;
+using FFXIVClientStructs.FFXIV.Client.Game;
+using Glamourer.Config;
+using Glamourer.Gui.Equipment;
+using Glamourer.Gui.Materials;
+using Glamourer.Gui.Tabs.ActorTab;
+using Glamourer.State;
+using ImSharp;
+using Luna;
+using Penumbra.GameData.Enums;
+
+namespace Glamourer.Gui;
+
+public class EquipmentBarWindow : Window, IDisposable
+{
+    private WindowFlags GetFlags
+        => _config.Ephemeral.LockEquipmentBar
+            ? WindowFlags.NoDecoration | WindowFlags.NoDocking | WindowFlags.NoFocusOnAppearing | WindowFlags.NoMove
+            : WindowFlags.NoDecoration | WindowFlags.NoDocking | WindowFlags.NoFocusOnAppearing;
+
+    private readonly Configuration    _config;
+    private readonly ActorSelection   _selection;
+    private readonly StateManager     _stateManager;
+    private readonly EquipmentDrawer  _equipmentDrawer;
+    private readonly MainWindow       _mainWindow;
+    private readonly ActorPanel       _actorPanel;
+    private readonly AdvancedDyePopup _advancedDyes;
+
+    private readonly Im.ColorStyleDisposable _style = new();
+
+    public EquipmentBarWindow(Configuration config, ActorSelection selection, StateManager stateManager, EquipmentDrawer equipmentDrawer,
+        MainWindow mainWindow, ActorPanel actorPanel, AdvancedDyePopup advancedDyes)
+        : base("Glamourer Equipment Bar", WindowFlags.NoDecoration | WindowFlags.NoDocking)
+    {
+        _config          = config;
+        _selection       = selection;
+        _stateManager    = stateManager;
+        _equipmentDrawer = equipmentDrawer;
+        _mainWindow      = mainWindow;
+        _actorPanel      = actorPanel;
+        _advancedDyes    = advancedDyes;
+
+        mainWindow.Open                       += OnMainWindowOpen;
+        actorPanel.OpenEquipmentBar += OnActorPanelOpenEqpBar;
+
+        Size               = Vector2.Zero;
+        RespectCloseHotkey = false;
+    }
+
+    public void Dispose()
+    {
+        _mainWindow.Open                       -= OnMainWindowOpen;
+        _actorPanel.OpenEquipmentBar -= OnActorPanelOpenEqpBar;
+    }
+
+    private void OnActorPanelOpenEqpBar()
+        => IsOpen = true;
+
+    private void OnMainWindowOpen()
+        => IsOpen = false;
+
+    public override void OnOpen()
+        => _mainWindow.IsOpen = false;
+
+    public override bool DrawConditions()
+        => _selection.State is not null;
+
+    public override void PreDraw()
+    {
+        Flags = GetFlags;
+
+        base.PreDraw();
+
+        _style.Push(ImStyleDouble.WindowPadding, new Vector2(Im.Style.GlobalScale * 4))
+            .Push(ImStyleSingle.WindowBorderThickness, 0);
+        _style.Push(ImGuiColor.WindowBackground, ColorId.QuickDesignBg.Value())
+            .Push(ImGuiColor.Button,          ColorId.QuickDesignButton.Value())
+            .Push(ImGuiColor.FrameBackground, ColorId.QuickDesignFrame.Value());
+    }
+
+    public override void PostDraw()
+        => _style.Dispose();
+
+    public override void Draw()
+    {
+        if (ImEx.Icon.LabeledButton(FontAwesomeIcon.TheaterMasks.Icon(), "Bk. to Main"u8, "Go back to Glamourer's Main Window."u8,
+                new Vector2(Im.Style.FrameHeight * 4.0f + Im.Style.ItemInnerSpacing.X * 3.0f, Im.Style.FrameHeight)))
+            _mainWindow.IsOpen = true;
+
+        _equipmentDrawer.Prepare();
+
+        foreach (var slot in EquipSlotExtensions.EqdpSlots)
+        {
+            var data = EquipDrawData.FromState(_stateManager, _selection.State!, slot);
+            _equipmentDrawer.DrawEquip(data, true);
+        }
+
+        var mainhand = EquipDrawData.FromState(_stateManager, _selection.State!, EquipSlot.MainHand);
+        var offhand  = EquipDrawData.FromState(_stateManager, _selection.State!, EquipSlot.OffHand);
+        _equipmentDrawer.DrawWeapons(mainhand, offhand, GameMain.IsInGPose(), true);
+
+        foreach (var slot in BonusExtensions.AllFlags)
+        {
+            var data = BonusDrawData.FromState(_stateManager, _selection.State!, slot);
+            _equipmentDrawer.DrawBonusItem(data, true);
+        }
+
+        _equipmentDrawer.DrawDragDropTooltip();
+
+        if (_selection.Data.Objects.Count > 0)
+        {
+            using var popupStyle = new Im.ColorStyleDisposable();
+            popupStyle.PushDefault(ImStyleDouble.WindowPadding);
+            popupStyle.PushDefault(ImStyleSingle.WindowBorderThickness);
+            popupStyle.PushDefault(ImGuiColor.WindowBackground);
+            popupStyle.PushDefault(ImGuiColor.Button);
+            popupStyle.PushDefault(ImGuiColor.FrameBackground);
+
+            _advancedDyes.Draw(_selection.Data.Objects.Last(), _selection.State!, true);
+        }
+    }
+}

--- a/Glamourer/Gui/GlamourerWindowSystem.cs
+++ b/Glamourer/Gui/GlamourerWindowSystem.cs
@@ -13,7 +13,7 @@ public sealed class GlamourerWindowSystem : IDisposable, IUiService
     private readonly MainWindow   _ui;
 
     public GlamourerWindowSystem(IUiBuilder uiBuilder, MainWindow ui, Configuration config, UnlocksTab unlocksTab, GlamourerChangelog changelog,
-        DesignQuickBar quick, AutomationTestWindow automationTest)
+        DesignQuickBar quick, EquipmentBarWindow equipment, AutomationTestWindow automationTest)
     {
         _uiBuilder    = uiBuilder;
         _ui           = ui;
@@ -22,6 +22,7 @@ public sealed class GlamourerWindowSystem : IDisposable, IUiService
         _windowSystem.AddWindow(unlocksTab);
         _windowSystem.AddWindow(changelog.Changelog);
         _windowSystem.AddWindow(quick);
+        _windowSystem.AddWindow(equipment);
         _windowSystem.AddWindow(automationTest);
         _uiBuilder.OpenMainUi            += _ui.Toggle;
         _uiBuilder.OpenConfigUi          += _ui.OpenSettings;

--- a/Glamourer/Gui/MainWindow.cs
+++ b/Glamourer/Gui/MainWindow.cs
@@ -17,9 +17,11 @@ public sealed class MainWindow : Window, IDisposable
     private readonly TabSelected     _tabSelected;
     private          bool            _ignorePenumbra;
 
+    public event Action? Open;
+
     public MainWindow(IDalamudPluginInterface pi, Configuration config, PenumbraService penumbra,
         MainTabBar mainTabBar, DesignQuickBar quickBar, TabSelected tabSelected)
-        : base("GlamourerMainWindow")
+        : base("###GlamourerMainWindow")
     {
         pi.UiBuilder.DisableGposeUiHide = true;
         SizeConstraints = new WindowSizeConstraints
@@ -50,6 +52,11 @@ public sealed class MainWindow : Window, IDisposable
     {
         IsOpen              = true;
         _mainTabBar.NextTab = arguments.Type;
+    }
+
+    public override void OnOpen()
+    {
+        Open?.Invoke();
     }
 
     public override void PreDraw()

--- a/Glamourer/Gui/Materials/AdvancedDyePopup.cs
+++ b/Glamourer/Gui/Materials/AdvancedDyePopup.cs
@@ -47,13 +47,13 @@ public sealed unsafe class AdvancedDyePopup(
         return true;
     }
 
-    public void DrawButton(EquipSlot slot, ColorParameter color)
-        => DrawButton(MaterialValueIndex.FromSlot(slot), color);
+    public void DrawButton(EquipSlot slot, ColorParameter color, bool normalCompact)
+        => DrawButton(MaterialValueIndex.FromSlot(slot), color, normalCompact, false);
 
-    public void DrawButton(BonusItemFlag slot, ColorParameter color)
-        => DrawButton(MaterialValueIndex.FromSlot(slot), color);
+    public void DrawButton(BonusItemFlag slot, ColorParameter color, bool normalCompact)
+        => DrawButton(MaterialValueIndex.FromSlot(slot), color, normalCompact, true);
 
-    private void DrawButton(MaterialValueIndex index, ColorParameter color)
+    private void DrawButton(MaterialValueIndex index, ColorParameter color, bool normalCompact, bool bonus)
     {
         if (config.HideDesignPanel.HasFlag(DesignPanelFlag.AdvancedDyes))
             return;
@@ -65,6 +65,12 @@ public sealed unsafe class AdvancedDyePopup(
         var (textColor, buttonColor) = isOpen
             ? (ColorId.HeaderButtons.Value(), ImGuiColor.ButtonActive.Get())
             : (color, ColorParameter.Default);
+
+        if (normalCompact)
+        {
+            Im.Cursor.Position += new Vector2(bonus ? Im.Style.FrameHeight + Im.Style.ItemSpacing.X : 0.0f,
+                (bonus ? 0.5f : -0.5f) * (Im.Style.FrameHeight + Im.Style.ItemSpacing.Y));
+        }
 
         using (ImStyleBorder.Frame.Push(textColor, 2 * Im.Style.GlobalScale, isOpen))
         {
@@ -209,23 +215,13 @@ public sealed unsafe class AdvancedDyePopup(
     }
 
     private void DrawWindow(ReadOnlySpan<FFXIVClientStructs.Interop.Pointer<Texture>> textures,
-        ReadOnlySpan<FFXIVClientStructs.Interop.Pointer<Material>> materials)
+        ReadOnlySpan<FFXIVClientStructs.Interop.Pointer<Material>> materials, bool centered)
     {
         var flags = WindowFlags.NoFocusOnAppearing
           | WindowFlags.NoCollapse
           | WindowFlags.NoDecoration
           | WindowFlags.NoResize
           | WindowFlags.NoDocking;
-
-        // Set position to the right of the main window when attached
-        // The downwards offset is implicit through child position.
-        if (config.KeepAdvancedDyesAttached)
-        {
-            var position = Im.Window.Position;
-            position.X += Im.Window.Size.X + Im.Style.WindowPadding.X;
-            Im.Window.SetNextPosition(position);
-            flags |= WindowFlags.NoMove;
-        }
 
         var width = 7 * Im.Style.FrameHeight // Buttons
           + 3 * Im.Style.ItemSpacing.X       // around text
@@ -234,6 +230,19 @@ public sealed unsafe class AdvancedDyePopup(
           + 7 * Im.Font.Mono.GetCharacterAdvance(' ') * Im.Style.GlobalScale // Row
           + 2 * Im.Style.WindowPadding.X;
         var height = 19 * Im.Style.FrameHeightWithSpacing + Im.Style.WindowPadding.Y + 3 * Im.Style.ItemSpacing.Y;
+
+        // Set position to the right of the main window when attached
+        // The downwards offset is implicit through child position.
+        if (config.KeepAdvancedDyesAttached)
+        {
+            var position = Im.Window.Position;
+            position.X += Im.Window.Size.X + Im.Style.WindowPadding.X;
+            if (centered)
+                position.Y += (Im.Window.Size.Y - height) * 0.5f;
+            Im.Window.SetNextPosition(position);
+            flags |= WindowFlags.NoMove;
+        }
+
         Im.Window.SetNextSize(new Vector2(width, height));
 
         using var window = Im.Window.Begin("###Glamourer Advanced Dyes"u8, flags);
@@ -247,7 +256,7 @@ public sealed unsafe class AdvancedDyePopup(
             DrawContent(textures, materials);
     }
 
-    public void Draw(Actor actor, ActorState state)
+    public void Draw(Actor actor, ActorState state, bool centered)
     {
         _actor = actor;
         _state = state;
@@ -255,7 +264,7 @@ public sealed unsafe class AdvancedDyePopup(
             return;
 
         if (_drawIndex!.Value.TryGetTextures(actor, out var textures, out var materials))
-            DrawWindow(textures, materials);
+            DrawWindow(textures, materials, centered);
     }
 
     private void DrawTable(MaterialValueIndex materialIndex, ColorTable.Table table)

--- a/Glamourer/Gui/Tabs/ActorTab/ActorPanel.cs
+++ b/Glamourer/Gui/Tabs/ActorTab/ActorPanel.cs
@@ -159,9 +159,28 @@ public sealed class ActorPanel : IPanel
         Im.Dummy(new Vector2(Im.Style.TextHeight / 2));
     }
 
+    private Im.HeaderDisposable EquipmentHeaderButton()
+    {
+        // Collapsible headers ignore SetNextItemWidth.
+        // Is there a better way to do that than this ugly hack?
+        var       itemSpacing = Im.Style.ItemSpacing.X;
+        var       availWidth  = Im.ContentRegion.Available.X;
+        using var style       = ImStyleDouble.ItemSpacing.PushX(0.0f);
+        using var columns     = Im.Columns(2, "###equipHeaderColumns"u8);
+        columns.SetWidth(0, availWidth - ImEx.Icon.CalculateLabeledButtonSize(LunaStyle.PopOutIcon, "Equipment Bar"u8).X - itemSpacing);
+        var header = DesignPanelFlag.Equipment.Header(_config);
+
+        columns.Next();
+        Im.Cursor.X += itemSpacing;
+        if (ImEx.Icon.LabeledButton(LunaStyle.PopOutIcon, "Equipment Bar"u8, "Switch to Equipment Bar."u8))
+            OpenEquipmentBar?.Invoke();
+
+        return header;
+    }
+
     private void DrawEquipmentHeader()
     {
-        using var h = DesignPanelFlag.Equipment.Header(_config);
+        using var h = EquipmentHeaderButton();
         if (!h)
             return;
 
@@ -170,9 +189,6 @@ public sealed class ActorPanel : IPanel
         var usedAllStain = _equipmentDrawer.DrawAllStain(out var newAllStain, _selection.State!.IsLocked);
         Im.Line.Same();
         EquipmentDrawer.DrawKeepItemFilter(_config);
-        Im.Line.Same();
-        if (ImEx.Icon.LabeledButton(LunaStyle.PopOutIcon, "Equip. Bar"u8, "Switch to Equipment Bar."u8))
-            OpenEquipmentBar?.Invoke();
         foreach (var slot in EquipSlotExtensions.EqdpSlots)
         {
             var data = EquipDrawData.FromState(_stateManager, _selection.State!, slot);

--- a/Glamourer/Gui/Tabs/ActorTab/ActorPanel.cs
+++ b/Glamourer/Gui/Tabs/ActorTab/ActorPanel.cs
@@ -1,4 +1,5 @@
-﻿using Dalamud.Interface.ImGuiNotification;
+﻿using Dalamud.Interface;
+using Dalamud.Interface.ImGuiNotification;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using Glamourer.Automation;
 using Glamourer.Config;
@@ -33,6 +34,8 @@ public sealed class ActorPanel : IPanel
     private readonly CustomizeParameterDrawer _parameterDrawer;
     private readonly AdvancedDyePopup         _advancedDyes;
     private readonly DesignApplier            _designApplier;
+
+    public event Action? OpenEquipmentBar;
 
     public ActorPanel(StateManager stateManager,
         CustomizationDrawer customizationDrawer,
@@ -124,7 +127,7 @@ public sealed class ActorPanel : IPanel
         else
             DrawMonsterPanel();
         if (_selection.Data.Objects.Count > 0)
-            _advancedDyes.Draw(_selection.Data.Objects.Last(), _selection.State);
+            _advancedDyes.Draw(_selection.Data.Objects.Last(), _selection.State, false);
     }
 
     private void DrawHumanPanel()
@@ -167,6 +170,9 @@ public sealed class ActorPanel : IPanel
         var usedAllStain = _equipmentDrawer.DrawAllStain(out var newAllStain, _selection.State!.IsLocked);
         Im.Line.Same();
         EquipmentDrawer.DrawKeepItemFilter(_config);
+        Im.Line.Same();
+        if (ImEx.Icon.LabeledButton(LunaStyle.PopOutIcon, "Equip. Bar"u8, "Switch to Equipment Bar."u8))
+            OpenEquipmentBar?.Invoke();
         foreach (var slot in EquipSlotExtensions.EqdpSlots)
         {
             var data = EquipDrawData.FromState(_stateManager, _selection.State!, slot);

--- a/Glamourer/Gui/Tabs/ActorTab/ActorPanel.cs
+++ b/Glamourer/Gui/Tabs/ActorTab/ActorPanel.cs
@@ -161,21 +161,36 @@ public sealed class ActorPanel : IPanel
 
     private Im.HeaderDisposable EquipmentHeaderButton()
     {
-        // Collapsible headers ignore SetNextItemWidth.
-        // Is there a better way to do that than this ugly hack?
-        var       spacing    = Im.Style.ItemInnerSpacing.X;
-        var       availWidth = Im.ContentRegion.Available.X;
-        using var style      = ImStyleDouble.ItemSpacing.PushX(0.0f);
-        using var columns    = Im.Columns(2, "###equipHeaderColumns"u8);
-        columns.SetWidth(0, availWidth - Im.Style.FrameHeight - spacing);
-        var header = DesignPanelFlag.Equipment.Header(_config);
-
-        columns.Next();
-        Im.Cursor.X += spacing;
-        if (ImEx.Icon.Button(LunaStyle.PopOutIcon, "Switch to the Equipment Bar."u8))
+        var savedCursor = Im.Cursor.Position;
+        var headerWidth = Im.ContentRegion.Available.X - ImEx.Icon.CalculateLabeledButtonSize(LunaStyle.PopOutIcon, ""u8).X;
+        Im.Cursor.X += headerWidth;
+        using var color = ImGuiColor.Button.Push(ImGuiColor.Header)
+            .Push(ImGuiColor.ButtonHovered, ImGuiColor.HeaderHovered)
+            .Push(ImGuiColor.ButtonActive,  ImGuiColor.HeaderActive);
+        if (ImEx.Icon.LabeledButton(LunaStyle.PopOutIcon, "###switchToEquipBar"u8, "Switch to the Equipment Bar."u8, corners: Corners.Right))
             OpenEquipmentBar?.Invoke();
+        Im.Cursor.Position = savedCursor;
 
-        return header;
+        var upperLeft  = Im.Cursor.ScreenPosition;
+        var lowerRight = upperLeft + new Vector2(headerWidth, Im.Style.FrameHeight);
+
+        // We have to shave off an epsilon of width, otherwise there is a pixel that is considered as hovering both parts of the widget.
+        var headerColor =
+            (Im.Mouse.IsHoveringRectangle(upperLeft, lowerRight - new Vector2(0.001f, 0.0f)), Im.Mouse.IsDown(MouseButton.Left)) switch
+            {
+                (true, true)  => ImGuiColor.ButtonActive,
+                (true, false) => ImGuiColor.ButtonHovered,
+                (false, _)    => ImGuiColor.Button,
+            };
+
+        Im.DrawList.Window.Shape.RectangleFilled(upperLeft, lowerRight, headerColor, Im.Style.FrameRounding,
+            ImDrawFlagsRectangle.RoundCornersLeft);
+
+        color.Push(ImGuiColor.Header, Rgba32.Transparent)
+            .Push(ImGuiColor.HeaderHovered, Rgba32.Transparent)
+            .Push(ImGuiColor.HeaderActive,  Rgba32.Transparent);
+
+        return DesignPanelFlag.Equipment.Header(_config);
     }
 
     private void DrawEquipmentHeader()

--- a/Glamourer/Gui/Tabs/ActorTab/ActorPanel.cs
+++ b/Glamourer/Gui/Tabs/ActorTab/ActorPanel.cs
@@ -163,16 +163,16 @@ public sealed class ActorPanel : IPanel
     {
         // Collapsible headers ignore SetNextItemWidth.
         // Is there a better way to do that than this ugly hack?
-        var       itemSpacing = Im.Style.ItemSpacing.X;
-        var       availWidth  = Im.ContentRegion.Available.X;
-        using var style       = ImStyleDouble.ItemSpacing.PushX(0.0f);
-        using var columns     = Im.Columns(2, "###equipHeaderColumns"u8);
-        columns.SetWidth(0, availWidth - ImEx.Icon.CalculateLabeledButtonSize(LunaStyle.PopOutIcon, "Equipment Bar"u8).X - itemSpacing);
+        var       spacing    = Im.Style.ItemInnerSpacing.X;
+        var       availWidth = Im.ContentRegion.Available.X;
+        using var style      = ImStyleDouble.ItemSpacing.PushX(0.0f);
+        using var columns    = Im.Columns(2, "###equipHeaderColumns"u8);
+        columns.SetWidth(0, availWidth - Im.Style.FrameHeight - spacing);
         var header = DesignPanelFlag.Equipment.Header(_config);
 
         columns.Next();
-        Im.Cursor.X += itemSpacing;
-        if (ImEx.Icon.LabeledButton(LunaStyle.PopOutIcon, "Equipment Bar"u8, "Switch to the Equipment Bar."u8))
+        Im.Cursor.X += spacing;
+        if (ImEx.Icon.Button(LunaStyle.PopOutIcon, "Switch to the Equipment Bar."u8))
             OpenEquipmentBar?.Invoke();
 
         return header;

--- a/Glamourer/Gui/Tabs/ActorTab/ActorPanel.cs
+++ b/Glamourer/Gui/Tabs/ActorTab/ActorPanel.cs
@@ -172,7 +172,7 @@ public sealed class ActorPanel : IPanel
 
         columns.Next();
         Im.Cursor.X += itemSpacing;
-        if (ImEx.Icon.LabeledButton(LunaStyle.PopOutIcon, "Equipment Bar"u8, "Switch to Equipment Bar."u8))
+        if (ImEx.Icon.LabeledButton(LunaStyle.PopOutIcon, "Equipment Bar"u8, "Switch to the Equipment Bar."u8))
             OpenEquipmentBar?.Invoke();
 
         return header;

--- a/Glamourer/Gui/Tabs/SettingsTab/SettingsTab.cs
+++ b/Glamourer/Gui/Tabs/SettingsTab/SettingsTab.cs
@@ -267,6 +267,9 @@ public sealed class SettingsTab(
             v => config.Ephemeral.LockMainWindow = v);
         Checkbox("Open Main Window at Game Start"u8, "Whether the main Glamourer window should be open or closed after launching the game."u8,
             config.OpenWindowAtStart,                v => config.OpenWindowAtStart = v);
+        EphemeralCheckbox("Lock Equipment Bar"u8, "Prevent the equipment bar from being moved and lock it in place."u8,
+            config.Ephemeral.LockEquipmentBar,
+            v => config.Ephemeral.LockEquipmentBar = v);
         Im.Dummy(Vector2.Zero);
         Im.Separator();
         Im.Dummy(Vector2.Zero);

--- a/Glamourer/Gui/UiHelpers.cs
+++ b/Glamourer/Gui/UiHelpers.cs
@@ -37,6 +37,7 @@ public static class UiHelpers
         else
         {
             Im.Image.DrawScaled(ptr, size, textureSize);
+            AddItemNameToTooltip(item, textureSize);
         }
     }
 
@@ -59,7 +60,19 @@ public static class UiHelpers
         else
         {
             Im.Image.DrawScaled(ptr, size, textureSize);
+            AddItemNameToTooltip(item, textureSize);
         }
+    }
+
+    private static void AddItemNameToTooltip(EquipItem item, Vector2 textureSize)
+    {
+        if (!Im.Item.Hovered(HoveredFlags.AllowWhenDisabled))
+            return;
+
+        using var tt = Im.Tooltip.Begin();
+        Im.Line.Same();
+        Im.Cursor.Y += Math.Max(0.0f, (textureSize.Y - Im.Style.TextHeight) * 0.5f);
+        Im.Text(item.Name);
     }
 
     public static bool DrawCheckbox(ReadOnlySpan<byte> label, Utf8StringHandler<TextStringHandlerBuffer> tooltip, bool value, out bool on, bool locked)


### PR DESCRIPTION
Requires Ottermandias/ImSharp#8.

This adds the Equipment Bar, which is a compact version of most of the Actors → Equipment UI.

The main intended purpose of this is to have an equipment UI that takes less space on the screen, to be able to fine-tune advanced dyes and other details without it getting in the way.

<img width="136" height="737" alt="image" src="https://github.com/user-attachments/assets/6d645b75-eed1-495d-978c-c0f5256129b9" />