### PR TITLE
Conditional design links

### DIFF
--- a/Glamourer/Automation/AutoDesign.cs
+++ b/Glamourer/Automation/AutoDesign.cs
@@ -2,39 +2,22 @@
 using Glamourer.Designs.Special;
 using Newtonsoft.Json.Linq;
 using Penumbra.GameData.Interop;
-using Penumbra.GameData.Structs;
 
 namespace Glamourer.Automation;
 
 public class AutoDesign
 {
-    public IDesignStandIn  Design = new RevertDesign();
-    public JobGroup        Jobs;
-    public ApplicationType Type;
-    public short           GearsetIndex = -1;
+    public IDesignStandIn   Design = new RevertDesign();
+    public ApplicationType  Type;
+    public DesignConditions Conditions;
 
     public AutoDesign Clone()
         => new()
         {
-            Design       = Design,
-            Type         = Type,
-            Jobs         = Jobs,
-            GearsetIndex = GearsetIndex,
+            Design     = Design,
+            Type       = Type,
+            Conditions = Conditions,
         };
-
-    public unsafe bool IsActive(Actor actor)
-    {
-        if (!actor.IsCharacter)
-            return false;
-
-        var ret = true;
-        if (GearsetIndex < 0)
-            ret &= Jobs.Fits(actor.AsCharacter->CharacterData.ClassJob);
-        else
-            ret &= AutoDesignApplier.CheckGearset(GearsetIndex);
-
-        return ret;
-    }
 
     public JObject Serialize()
     {
@@ -42,20 +25,9 @@ public class AutoDesign
         {
             ["Design"]     = Design.SerializeName(),
             ["Type"]       = (uint)Type,
-            ["Conditions"] = CreateConditionObject(),
+            ["Conditions"] = Conditions.Data.Serialize(),
         };
         Design.AddData(ret);
-        return ret;
-    }
-
-    private JObject CreateConditionObject()
-    {
-        var ret = new JObject
-        {
-            ["Gearset"]  = GearsetIndex,
-            ["JobGroup"] = Jobs.Id.Id,
-        };
-
         return ret;
     }
 

--- a/Glamourer/Automation/AutoDesignApplier.cs
+++ b/Glamourer/Automation/AutoDesignApplier.cs
@@ -284,8 +284,9 @@ public sealed class AutoDesignApplier : IDisposable, IRequiredService
             return;
 
         var mergedDesign = _designMerger.Merge(
-            set.Designs.Where(d => d.IsActive(actor))
-                .SelectMany(d => d.Design.AllLinks(newApplication).Select(l => (l.Design, l.Flags & d.Type, d.Jobs.Flags))),
+            set.Designs.Where(d => d.Conditions.Match(actor))
+                .SelectMany(d => d.Design.AllLinks(newApplication, cond => cond.Match(actor))
+                    .Select(l => (l.Design, l.Flags & d.Type, d.Conditions.JobFlags))),
             state.ModelData.Customize, state.BaseData, true, _config.AlwaysApplyAssociatedMods);
 
         if (_objects.IsInGPose && actor.IsGPoseOrCutscene)

--- a/Glamourer/Automation/AutoDesignManager.cs
+++ b/Glamourer/Automation/AutoDesignManager.cs
@@ -20,13 +20,14 @@ public sealed class AutoDesignManager : ISavable, IReadOnlyList<AutoDesignSet>, 
 
     private readonly SaveService _saveService;
 
-    private readonly JobService            _jobs;
-    private readonly DesignManager         _designs;
-    private readonly ActorManager          _actors;
-    private readonly AutomationChanged     _event;
-    private readonly DesignChanged         _designEvent;
-    private readonly RandomDesignGenerator _randomDesigns;
-    private readonly QuickSelectedDesign   _quickSelectedDesign;
+    private readonly JobService                   _jobs;
+    private readonly DesignManager                _designs;
+    private readonly ActorManager                 _actors;
+    private readonly AutomationChanged            _event;
+    private readonly DesignChanged                _designEvent;
+    private readonly RandomDesignGenerator        _randomDesigns;
+    private readonly QuickSelectedDesign          _quickSelectedDesign;
+    private readonly DesignConditionsHydrator _conditionsHydrator;
 
     private readonly List<AutoDesignSet>                        _data    = [];
     private          Dictionary<ActorIdentifier, AutoDesignSet> _enabled = [];
@@ -36,16 +37,17 @@ public sealed class AutoDesignManager : ISavable, IReadOnlyList<AutoDesignSet>, 
 
     public AutoDesignManager(JobService jobs, ActorManager actors, SaveService saveService, DesignManager designs, AutomationChanged @event,
         FixedDesignMigrator migrator, DesignFileSystem fileSystem, DesignChanged designEvent, RandomDesignGenerator randomDesigns,
-        QuickSelectedDesign quickSelectedDesign)
+        QuickSelectedDesign quickSelectedDesign, DesignConditionsHydrator conditionsHydrator)
     {
-        _jobs                = jobs;
-        _actors              = actors;
-        _saveService         = saveService;
-        _designs             = designs;
-        _event               = @event;
-        _designEvent         = designEvent;
-        _randomDesigns       = randomDesigns;
-        _quickSelectedDesign = quickSelectedDesign;
+        _jobs                   = jobs;
+        _actors                 = actors;
+        _saveService            = saveService;
+        _designs                = designs;
+        _event                  = @event;
+        _designEvent            = designEvent;
+        _randomDesigns          = randomDesigns;
+        _quickSelectedDesign    = quickSelectedDesign;
+        _conditionsHydrator = conditionsHydrator;
         _designEvent.Subscribe(OnDesignChange, DesignChanged.Priority.AutoDesignManager);
         Load();
         migrator.ConsumeMigratedData(_actors, fileSystem, this);
@@ -285,9 +287,9 @@ public sealed class AutoDesignManager : ISavable, IReadOnlyList<AutoDesignSet>, 
     {
         var newDesign = new AutoDesign
         {
-            Design = design,
-            Type   = ApplicationType.All,
-            Jobs   = _jobs.JobGroups[1],
+            Design     = design,
+            Type       = ApplicationType.All,
+            Conditions = _conditionsHydrator.AlwaysTrue,
         };
         set.Designs.Add(newDesign);
         Save();
@@ -349,37 +351,21 @@ public sealed class AutoDesignManager : ISavable, IReadOnlyList<AutoDesignSet>, 
         _event.Invoke(new AutomationChanged.ChangedDesignArguments(set, which, old, newDesign));
     }
 
-    public void ChangeJobCondition(AutoDesignSet set, int which, JobGroup jobs)
+    public void ChangeConditions(AutoDesignSet set, int which, DesignConditions conditions)
     {
         if (which >= set.Designs.Count || which < 0)
             return;
 
         var design = set.Designs[which];
 
-        if (design.Jobs.Id == jobs.Id)
+        if (design.Conditions == conditions)
             return;
 
-        var old = design.Jobs;
-        design.Jobs = jobs;
+        var old = design.Conditions;
+        design.Conditions = conditions;
         Save();
-        Glamourer.Log.Debug($"Changed job condition from {old.Id} to {jobs.Id} for associated design {which + 1} in design set.");
-        _event.Invoke(new AutomationChanged.ChangedConditionsArguments(set, which, old, jobs));
-    }
-
-    public void ChangeGearsetCondition(AutoDesignSet set, int which, short index)
-    {
-        if (which >= set.Designs.Count || which < 0)
-            return;
-
-        var design = set.Designs[which];
-        if (design.GearsetIndex == index)
-            return;
-
-        var old = design.GearsetIndex;
-        design.GearsetIndex = index;
-        Save();
-        Glamourer.Log.Debug($"Changed gearset condition from {old} to {index} for associated design {which + 1} in design set.");
-        _event.Invoke(new AutomationChanged.ChangedConditionsArguments(set, which, default, default));
+        Glamourer.Log.Debug($"Changed conditions from {old} to {conditions} for associated design {which + 1} in design set.");
+        _event.Invoke(new AutomationChanged.ChangedConditionsArguments(set, which, old, conditions));
     }
 
     public void ChangeApplicationType(AutoDesignSet set, int which, ApplicationType applicationType)
@@ -654,28 +640,7 @@ public sealed class AutoDesignManager : ISavable, IReadOnlyList<AutoDesignSet>, 
     }
 
     private bool ParseConditions(string setName, JObject jObj, AutoDesign ret)
-    {
-        var conditions = jObj["Conditions"];
-        if (conditions is null)
-            return true;
-
-        var jobs = conditions["JobGroup"]?.ToObject<int>() ?? -1;
-        if (jobs >= 0)
-        {
-            if (!_jobs.JobGroups.TryGetValue((JobGroupId)jobs, out var jobGroup))
-            {
-                Glamourer.Messager.NotificationMessage(
-                    $"Error parsing automatically applied design for set {setName}: The job condition {jobs} does not exist.",
-                    NotificationType.Warning);
-                return false;
-            }
-
-            ret.Jobs = jobGroup;
-        }
-
-        ret.GearsetIndex = conditions["Gearset"]?.ToObject<short>() ?? -1;
-        return true;
-    }
+        => _conditionsHydrator.TryHydrate(jObj["Conditions"], out ret.Conditions, "automatically applied design for set", setName);
 
     private void Save()
         => _saveService.DelaySave(this);

--- a/Glamourer/Automation/AutoDesignManager.cs
+++ b/Glamourer/Automation/AutoDesignManager.cs
@@ -3,7 +3,6 @@ using Dalamud.Interface.ImGuiNotification;
 using Glamourer.Designs;
 using Glamourer.Designs.Special;
 using Glamourer.Events;
-using Glamourer.Interop;
 using Glamourer.Services;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -20,14 +19,13 @@ public sealed class AutoDesignManager : ISavable, IReadOnlyList<AutoDesignSet>, 
 
     private readonly SaveService _saveService;
 
-    private readonly JobService                   _jobs;
-    private readonly DesignManager                _designs;
-    private readonly ActorManager                 _actors;
-    private readonly AutomationChanged            _event;
-    private readonly DesignChanged                _designEvent;
-    private readonly RandomDesignGenerator        _randomDesigns;
-    private readonly QuickSelectedDesign          _quickSelectedDesign;
-    private readonly DesignConditionsHydrator _conditionsHydrator;
+    private readonly DesignManager          _designs;
+    private readonly ActorManager           _actors;
+    private readonly AutomationChanged      _event;
+    private readonly DesignChanged          _designEvent;
+    private readonly RandomDesignGenerator  _randomDesigns;
+    private readonly QuickSelectedDesign    _quickSelectedDesign;
+    private readonly DesignConditionsLoader _conditionsLoader;
 
     private readonly List<AutoDesignSet>                        _data    = [];
     private          Dictionary<ActorIdentifier, AutoDesignSet> _enabled = [];
@@ -35,19 +33,18 @@ public sealed class AutoDesignManager : ISavable, IReadOnlyList<AutoDesignSet>, 
     public IReadOnlyDictionary<ActorIdentifier, AutoDesignSet> EnabledSets
         => _enabled;
 
-    public AutoDesignManager(JobService jobs, ActorManager actors, SaveService saveService, DesignManager designs, AutomationChanged @event,
+    public AutoDesignManager(ActorManager actors, SaveService saveService, DesignManager designs, AutomationChanged @event,
         FixedDesignMigrator migrator, DesignFileSystem fileSystem, DesignChanged designEvent, RandomDesignGenerator randomDesigns,
-        QuickSelectedDesign quickSelectedDesign, DesignConditionsHydrator conditionsHydrator)
+        QuickSelectedDesign quickSelectedDesign, DesignConditionsLoader conditionsLoader)
     {
-        _jobs                   = jobs;
-        _actors                 = actors;
-        _saveService            = saveService;
-        _designs                = designs;
-        _event                  = @event;
-        _designEvent            = designEvent;
-        _randomDesigns          = randomDesigns;
-        _quickSelectedDesign    = quickSelectedDesign;
-        _conditionsHydrator = conditionsHydrator;
+        _actors              = actors;
+        _saveService         = saveService;
+        _designs             = designs;
+        _event               = @event;
+        _designEvent         = designEvent;
+        _randomDesigns       = randomDesigns;
+        _quickSelectedDesign = quickSelectedDesign;
+        _conditionsLoader    = conditionsLoader;
         _designEvent.Subscribe(OnDesignChange, DesignChanged.Priority.AutoDesignManager);
         Load();
         migrator.ConsumeMigratedData(_actors, fileSystem, this);
@@ -289,7 +286,7 @@ public sealed class AutoDesignManager : ISavable, IReadOnlyList<AutoDesignSet>, 
         {
             Design     = design,
             Type       = ApplicationType.All,
-            Conditions = _conditionsHydrator.AlwaysTrue,
+            Conditions = _conditionsLoader.AlwaysTrue,
         };
         set.Designs.Add(newDesign);
         Save();
@@ -640,7 +637,7 @@ public sealed class AutoDesignManager : ISavable, IReadOnlyList<AutoDesignSet>, 
     }
 
     private bool ParseConditions(string setName, JObject jObj, AutoDesign ret)
-        => _conditionsHydrator.TryHydrate(jObj["Conditions"], out ret.Conditions, "automatically applied design for set", setName);
+        => _conditionsLoader.TryParse(jObj["Conditions"], out ret.Conditions, "automatically applied design for set", setName);
 
     private void Save()
         => _saveService.DelaySave(this);
@@ -661,6 +658,7 @@ public sealed class AutoDesignManager : ISavable, IReadOnlyList<AutoDesignSet>, 
             group = [];
             return false;
         }
+
         group = GetGroup(identifier.WithoutIndex());
         return group.Length > 0;
     }

--- a/Glamourer/Automation/AutomationTestCache.cs
+++ b/Glamourer/Automation/AutomationTestCache.cs
@@ -115,7 +115,7 @@ public sealed class AutomationTestCache : BasicCache, IReadOnlyList<AutomationTe
         }
     }
 
-    public int GearSet
+    public short GearSet
     {
         get;
         set
@@ -129,7 +129,7 @@ public sealed class AutomationTestCache : BasicCache, IReadOnlyList<AutomationTe
     }
 
     public AutomationTestCache(AutomationChanged automationChanged, AutomationSelection selection, Configuration config, ItemManager items,
-        int gearSet, JobId job)
+        short gearSet, JobId job)
     {
         _automationChanged          =  automationChanged;
         _selection                  =  selection;
@@ -190,18 +190,11 @@ public sealed class AutomationTestCache : BasicCache, IReadOnlyList<AutomationTe
 
         foreach (var design in set.Designs)
         {
-            if (design.GearsetIndex >= 0)
-            {
-                if (GearSet != design.GearsetIndex)
-                    continue;
-            }
-            else if (!design.Jobs.Fits(Job))
-            {
+            if (!design.Conditions.Match(Job, GearSet))
                 continue;
-            }
 
             var designName = new StringU8(design.Design.ResolveName(_config.Ephemeral.IncognitoMode));
-            foreach (var (link, flags, _) in design.Design.AllLinks(true))
+            foreach (var (link, flags, _) in design.Design.AllLinks(true, cond => cond.Match(Job, GearSet)))
             {
                 var application = (design.Type & flags).ApplyWhat(link);
                 if (!_resetsAssociations && link.ResetTemporarySettings)

--- a/Glamourer/Automation/FixedDesignMigrator.cs
+++ b/Glamourer/Automation/FixedDesignMigrator.cs
@@ -55,7 +55,7 @@ public sealed class FixedDesignMigrator(JobService jobs) : IRequiredService
                 }
 
                 autoManager.AddDesign(set, leaf.Value);
-                autoManager.ChangeJobCondition(set, set.Designs.Count - 1, design.Item2);
+                autoManager.ChangeConditions(set, set.Designs.Count - 1, new DesignConditions(design.Item2));
                 autoManager.ChangeApplicationType(set, set.Designs.Count - 1, design.Item3 ? ApplicationType.All : 0);
             }
         }

--- a/Glamourer/Designs/Design.cs
+++ b/Glamourer/Designs/Design.cs
@@ -62,8 +62,9 @@ public sealed class Design : DesignBase, ISavable, IDesignStandIn, IFileSystemVa
     public string Incognito
         => Identifier.ToString()[..8];
 
-    public IEnumerable<(IDesignStandIn Design, ApplicationType Flags, JobFlag Jobs)> AllLinks(bool newApplication)
-        => LinkContainer.GetAllLinks(this).Select(t => ((IDesignStandIn)t.Link.Link, t.Link.Type, JobFlag.All));
+    public IEnumerable<(IDesignStandIn Design, ApplicationType Flags, JobFlag Jobs)> AllLinks(bool newApplication,
+        Predicate<DesignConditions>? condition)
+        => LinkContainer.GetAllLinks(this, condition).Select(t => ((IDesignStandIn)t.Link.Link, t.Link.Type, JobFlag.All));
 
     #endregion
 
@@ -329,7 +330,8 @@ public sealed class Design : DesignBase, ISavable, IDesignStandIn, IFileSystemVa
             {
                 var identifier = jObj["Design"]?.ToObject<Guid>() ?? throw new ArgumentNullException(nameof(design));
                 var type       = (ApplicationType)(jObj["Type"]?.ToObject<uint>() ?? 0);
-                linkLoader.AddObject(design, new LinkData(identifier, type, order));
+                var conditions = DesignConditionData.Deserialize(jObj["Conditions"]);
+                linkLoader.AddObject(design, new LinkData(identifier, type, conditions, order));
             }
         }
     }

--- a/Glamourer/Designs/DesignConditionLoader.cs
+++ b/Glamourer/Designs/DesignConditionLoader.cs
@@ -6,7 +6,7 @@ using Penumbra.GameData.Structs;
 
 namespace Glamourer.Designs;
 
-public class DesignConditionsHydrator(JobService jobs) : IService
+public class DesignConditionsLoader(JobService jobs) : IService
 {
     public DesignConditions AlwaysTrue
         => new(jobs.JobGroups[1]);
@@ -14,10 +14,10 @@ public class DesignConditionsHydrator(JobService jobs) : IService
     public DesignConditions Canonicalize(DesignConditions conditions)
         => conditions.Constant is true ? AlwaysTrue : conditions;
 
-    public bool TryHydrate(JToken? token, out DesignConditions conditions, string? descriptionPrefix, string description)
+    public bool TryParse(JToken? token, out DesignConditions conditions, string? descriptionPrefix, string description)
     {
         var data    = DesignConditionData.Deserialize(token);
-        var success = TryHydrate(data, out conditions);
+        var success = TryConvert(data, out conditions);
         if (!success && descriptionPrefix is not null)
             Glamourer.Messager.NotificationMessage(
                 $"Error parsing {descriptionPrefix} {description}: The job condition {data.JobGroupId} does not exist.",
@@ -26,7 +26,7 @@ public class DesignConditionsHydrator(JobService jobs) : IService
         return success;
     }
 
-    public bool TryHydrate(DesignConditionData data, out DesignConditions conditions)
+    public bool TryConvert(DesignConditionData data, out DesignConditions conditions)
     {
         if (data.JobGroupId < 0)
         {

--- a/Glamourer/Designs/DesignConditions.cs
+++ b/Glamourer/Designs/DesignConditions.cs
@@ -1,0 +1,78 @@
+using Glamourer.Automation;
+using ImSharp;
+using Newtonsoft.Json.Linq;
+using Penumbra.GameData.Interop;
+using Penumbra.GameData.Structs;
+
+namespace Glamourer.Designs;
+
+public readonly record struct DesignConditions(JobGroup Jobs, short GearsetIndex = -1, bool? Constant = null)
+{
+    public static readonly DesignConditions AlwaysTrue = new(default, Constant: true);
+
+    public DesignConditionData Data
+        => Constant switch
+        {
+            true => new DesignConditionData(1),
+            null => new DesignConditionData(Jobs.Id.Id, GearsetIndex),
+            // "Always False" is not supposed to be constructed at the time of writing, and is therefore not supported for serialization.
+            false => throw new NotSupportedException(),
+        };
+
+    public JobFlag JobFlags
+        => Constant switch
+        {
+            true  => JobFlag.All,
+            false => 0,
+            null  => Jobs.Flags,
+        };
+
+    public unsafe bool Match(Actor actor)
+    {
+        if (Constant is { } value)
+            return value;
+
+        if (!actor.IsCharacter)
+            return false;
+
+        return GearsetIndex < 0
+            ? Jobs.Fits(actor.AsCharacter->CharacterData.ClassJob)
+            : AutoDesignApplier.CheckGearset(GearsetIndex);
+    }
+
+    public bool Match(JobId job, short gearset)
+        => Constant
+         ?? (GearsetIndex < 0
+                ? Jobs.Fits(job)
+                : gearset == GearsetIndex);
+
+    public override string ToString()
+        => Constant is { } value ? $"Always {value}" :
+            GearsetIndex is -1   ? $"Jobs: {Jobs.Name}" : $"Gearset: {GearsetIndex}";
+
+    public StringU8 ToJobsRestrictionString()
+        => Constant is null && GearsetIndex is -1 ? Jobs.Name : StringU8.Empty;
+
+    public StringU8 ToGearSetRestrictionString()
+        => Constant is not null || GearsetIndex is -1 ? StringU8.Empty : new StringU8($"{GearsetIndex}");
+}
+
+public readonly record struct DesignConditionData(int JobGroupId, short GearsetIndex = -1)
+{
+    public JObject Serialize()
+        => new JObject
+        {
+            ["Gearset"]  = GearsetIndex,
+            ["JobGroup"] = JobGroupId,
+        };
+
+    public static DesignConditionData Deserialize(JToken? token)
+    {
+        if (token is null)
+            return new DesignConditionData(-1);
+
+        return new DesignConditionData(
+            token["JobGroup"]?.ToObject<int>() ?? -1,
+            token["Gearset"]?.ToObject<short>() ?? -1);
+    }
+}

--- a/Glamourer/Designs/DesignConditionsHydrator.cs
+++ b/Glamourer/Designs/DesignConditionsHydrator.cs
@@ -1,0 +1,46 @@
+using Dalamud.Interface.ImGuiNotification;
+using Glamourer.Interop;
+using Luna;
+using Newtonsoft.Json.Linq;
+using Penumbra.GameData.Structs;
+
+namespace Glamourer.Designs;
+
+public class DesignConditionsHydrator(JobService jobs) : IService
+{
+    public DesignConditions AlwaysTrue
+        => new(jobs.JobGroups[1]);
+
+    public DesignConditions Canonicalize(DesignConditions conditions)
+        => conditions.Constant is true ? AlwaysTrue : conditions;
+
+    public bool TryHydrate(JToken? token, out DesignConditions conditions, string? descriptionPrefix, string description)
+    {
+        var data    = DesignConditionData.Deserialize(token);
+        var success = TryHydrate(data, out conditions);
+        if (!success && descriptionPrefix is not null)
+            Glamourer.Messager.NotificationMessage(
+                $"Error parsing {descriptionPrefix} {description}: The job condition {data.JobGroupId} does not exist.",
+                NotificationType.Warning);
+
+        return success;
+    }
+
+    public bool TryHydrate(DesignConditionData data, out DesignConditions conditions)
+    {
+        if (data.JobGroupId < 0)
+        {
+            conditions = new DesignConditions(jobs.JobGroups[1], data.GearsetIndex);
+            return true;
+        }
+
+        if (jobs.JobGroups.TryGetValue((JobGroupId)data.JobGroupId, out var jobGroup))
+        {
+            conditions = new DesignConditions(jobGroup, data.GearsetIndex);
+            return true;
+        }
+
+        conditions = new DesignConditions(default, data.GearsetIndex);
+        return false;
+    }
+}

--- a/Glamourer/Designs/IDesignStandIn.cs
+++ b/Glamourer/Designs/IDesignStandIn.cs
@@ -1,4 +1,5 @@
 ﻿using Glamourer.Automation;
+using Glamourer.Designs.Links;
 using Glamourer.Interop.Material;
 using Glamourer.State;
 using Newtonsoft.Json.Linq;
@@ -16,7 +17,8 @@ public interface IDesignStandIn : IEquatable<IDesignStandIn>
     public string      SerializeName();
     public StateSource AssociatedSource();
 
-    public IEnumerable<(IDesignStandIn Design, ApplicationType Flags, JobFlag Jobs)> AllLinks(bool newApplication);
+    public IEnumerable<(IDesignStandIn Design, ApplicationType Flags, JobFlag Jobs)> AllLinks(bool newApplication,
+        Predicate<DesignConditions>? condition);
 
     public void AddData(JObject jObj);
 

--- a/Glamourer/Designs/Links/DesignLink.cs
+++ b/Glamourer/Designs/Links/DesignLink.cs
@@ -2,9 +2,9 @@
 
 namespace Glamourer.Designs.Links;
 
-public record struct DesignLink(Design Link, ApplicationType Type);
+public record struct DesignLink(Design Link, ApplicationType Type, DesignConditions Conditions);
 
-public readonly record struct LinkData(Guid Identity, ApplicationType Type, LinkOrder Order)
+public readonly record struct LinkData(Guid Identity, ApplicationType Type, DesignConditionData Conditions, LinkOrder Order)
 {
     public override string ToString()
         => Identity.ToString();

--- a/Glamourer/Designs/Links/DesignLinkLoader.cs
+++ b/Glamourer/Designs/Links/DesignLinkLoader.cs
@@ -3,7 +3,7 @@ using Notification = Luna.Notification;
 
 namespace Glamourer.Designs.Links;
 
-public sealed class DesignLinkLoader(DesignStorage designStorage, MessageService messager)
+public sealed class DesignLinkLoader(DesignStorage designStorage, MessageService messager, DesignConditionsHydrator conditionsHydrator)
     : DelayedReferenceLoader<Design, Design, LinkData>(messager), IService
 {
     protected override bool TryGetObject(in LinkData data, [NotNullWhen(true)] out Design? obj)
@@ -13,7 +13,10 @@ public sealed class DesignLinkLoader(DesignStorage designStorage, MessageService
     }
 
     protected override bool SetObject(Design parent, Design child, in LinkData data, out string error)
-        => LinkContainer.AddLink(parent, child, data.Type, data.Order, out error);
+    {
+        conditionsHydrator.TryHydrate(data.Conditions, out var conditions);
+        return LinkContainer.AddLink(parent, child, data.Type, conditions, data.Order, out error);
+    }
 
     protected override void HandleChildNotFound(Design parent, in LinkData data)
     {

--- a/Glamourer/Designs/Links/DesignLinkLoader.cs
+++ b/Glamourer/Designs/Links/DesignLinkLoader.cs
@@ -3,7 +3,7 @@ using Notification = Luna.Notification;
 
 namespace Glamourer.Designs.Links;
 
-public sealed class DesignLinkLoader(DesignStorage designStorage, MessageService messager, DesignConditionsHydrator conditionsHydrator)
+public sealed class DesignLinkLoader(DesignStorage designStorage, MessageService messager, DesignConditionsLoader conditionsLoader)
     : DelayedReferenceLoader<Design, Design, LinkData>(messager), IService
 {
     protected override bool TryGetObject(in LinkData data, [NotNullWhen(true)] out Design? obj)
@@ -14,7 +14,7 @@ public sealed class DesignLinkLoader(DesignStorage designStorage, MessageService
 
     protected override bool SetObject(Design parent, Design child, in LinkData data, out string error)
     {
-        conditionsHydrator.TryHydrate(data.Conditions, out var conditions);
+        conditionsLoader.TryConvert(data.Conditions, out var conditions);
         return LinkContainer.AddLink(parent, child, data.Type, conditions, data.Order, out error);
     }
 

--- a/Glamourer/Designs/Links/DesignLinkManager.cs
+++ b/Glamourer/Designs/Links/DesignLinkManager.cs
@@ -7,17 +7,17 @@ namespace Glamourer.Designs.Links;
 
 public sealed class DesignLinkManager : IService, IDisposable
 {
-    private readonly DesignStorage            _storage;
-    private readonly DesignChanged            _event;
-    private readonly SaveService              _saveService;
-    private readonly DesignConditionsHydrator _conditionsHydrator;
+    private readonly DesignStorage          _storage;
+    private readonly DesignChanged          _event;
+    private readonly SaveService            _saveService;
+    private readonly DesignConditionsLoader _conditionsLoader;
 
-    public DesignLinkManager(DesignStorage storage, DesignChanged @event, SaveService saveService, DesignConditionsHydrator conditionsHydrator)
+    public DesignLinkManager(DesignStorage storage, DesignChanged @event, SaveService saveService, DesignConditionsLoader conditionsLoader)
     {
-        _storage            = storage;
-        _event              = @event;
-        _saveService        = saveService;
-        _conditionsHydrator = conditionsHydrator;
+        _storage          = storage;
+        _event            = @event;
+        _saveService      = saveService;
+        _conditionsLoader = conditionsLoader;
 
         _event.Subscribe(OnDesignChanged, DesignChanged.Priority.DesignLinkManager);
     }
@@ -38,7 +38,7 @@ public sealed class DesignLinkManager : IService, IDisposable
 
     public void AddDesignLink(Design parent, Design child, LinkOrder order)
     {
-        if (!LinkContainer.AddLink(parent, child, ApplicationType.All, _conditionsHydrator.AlwaysTrue, order, out _))
+        if (!LinkContainer.AddLink(parent, child, ApplicationType.All, _conditionsLoader.AlwaysTrue, order, out _))
             return;
 
         parent.LastEdit = DateTimeOffset.UtcNow;

--- a/Glamourer/Designs/Links/DesignLinkManager.cs
+++ b/Glamourer/Designs/Links/DesignLinkManager.cs
@@ -7,15 +7,17 @@ namespace Glamourer.Designs.Links;
 
 public sealed class DesignLinkManager : IService, IDisposable
 {
-    private readonly DesignStorage _storage;
-    private readonly DesignChanged _event;
-    private readonly SaveService   _saveService;
+    private readonly DesignStorage            _storage;
+    private readonly DesignChanged            _event;
+    private readonly SaveService              _saveService;
+    private readonly DesignConditionsHydrator _conditionsHydrator;
 
-    public DesignLinkManager(DesignStorage storage, DesignChanged @event, SaveService saveService)
+    public DesignLinkManager(DesignStorage storage, DesignChanged @event, SaveService saveService, DesignConditionsHydrator conditionsHydrator)
     {
-        _storage     = storage;
-        _event       = @event;
-        _saveService = saveService;
+        _storage            = storage;
+        _event              = @event;
+        _saveService        = saveService;
+        _conditionsHydrator = conditionsHydrator;
 
         _event.Subscribe(OnDesignChanged, DesignChanged.Priority.DesignLinkManager);
     }
@@ -36,7 +38,7 @@ public sealed class DesignLinkManager : IService, IDisposable
 
     public void AddDesignLink(Design parent, Design child, LinkOrder order)
     {
-        if (!LinkContainer.AddLink(parent, child, ApplicationType.All, order, out _))
+        if (!LinkContainer.AddLink(parent, child, ApplicationType.All, _conditionsHydrator.AlwaysTrue, order, out _))
             return;
 
         parent.LastEdit = DateTimeOffset.UtcNow;
@@ -65,6 +67,17 @@ public sealed class DesignLinkManager : IService, IDisposable
         _saveService.QueueSave(parent);
         Glamourer.Log.Debug(
             $"Changed link application type from {old} to {applicationType} for design link {order} {idx + 1} in design {parent.Identifier}.");
+        _event.Invoke(new DesignChanged.Arguments(DesignChanged.Type.ChangedLink, parent));
+    }
+
+    public void ChangeConditions(Design parent, int idx, LinkOrder order, DesignConditions conditions)
+    {
+        if (!parent.Links.ChangeConditions(idx, order, conditions, out var old))
+            return;
+
+        _saveService.QueueSave(parent);
+        Glamourer.Log.Debug(
+            $"Changed link conditions from {old} to {conditions} for design link {order} {idx + 1} in design {parent.Identifier}.");
         _event.Invoke(new DesignChanged.Arguments(DesignChanged.Type.ChangedLink, parent));
     }
 

--- a/Glamourer/Designs/Links/LinkContainer.cs
+++ b/Glamourer/Designs/Links/LinkContainer.cs
@@ -66,20 +66,34 @@ public sealed class LinkContainer : List<DesignLink>
         list.RemoveAt(idx);
         return true;
     }
-
-    public bool ChangeApplicationRules(int idx, LinkOrder order, ApplicationType type, out ApplicationType old)
-    {
-        var list = order switch
+    
+    private List<DesignLink> GetList(LinkOrder order)
+        => order switch
         {
             LinkOrder.Before => Before,
             LinkOrder.After  => After,
             _                => throw new ArgumentException("Invalid link order."),
         };
+
+    public bool ChangeApplicationRules(int idx, LinkOrder order, ApplicationType type, out ApplicationType old)
+    {
+        var list = GetList(order);
         old = list[idx].Type;
         if (idx < 0 || idx >= list.Count || old == type)
             return false;
 
         list[idx] = list[idx] with { Type = type };
+        return true;
+    }
+
+    public bool ChangeConditions(int idx, LinkOrder order, DesignConditions conditions, out DesignConditions old)
+    {
+        var list = GetList(order);
+        old = list[idx].Conditions;
+        if (idx < 0 || idx >= list.Count || old == conditions)
+            return false;
+
+        list[idx] = list[idx] with { Conditions = conditions };
         return true;
     }
 
@@ -97,14 +111,14 @@ public sealed class LinkContainer : List<DesignLink>
             return false;
         }
 
-        if (GetAllLinks(parent).Any(l => l.Link.Link == child && l.Order != order))
+        if (GetAllLinks(parent, null).Any(l => l.Link.Link == child && l.Order != order))
         {
             error =
                 $"Adding {child.Incognito} to {parent.Incognito}s links would create a circle, the parent already links to the child in the opposite direction.";
             return false;
         }
 
-        if (GetAllLinks(child).Any(l => l.Link.Link == parent && l.Order == order))
+        if (GetAllLinks(child, null).Any(l => l.Link.Link == parent && l.Order == order))
         {
             error =
                 $"Adding {child.Incognito} to {parent.Incognito}s links would create a circle, the child already links to the parent in the opposite direction.";
@@ -115,7 +129,8 @@ public sealed class LinkContainer : List<DesignLink>
         return true;
     }
 
-    public static bool AddLink(Design parent, Design child, ApplicationType type, LinkOrder order, out string error)
+    public static bool AddLink(Design parent, Design child, ApplicationType type, DesignConditions conditions, LinkOrder order,
+        out string error)
     {
         if (!CanAddLink(parent, child, order, out error))
             return false;
@@ -134,7 +149,7 @@ public sealed class LinkContainer : List<DesignLink>
         }
 
         type &= ApplicationType.All;
-        list.Add(new DesignLink(child, type));
+        list.Add(new DesignLink(child, type, conditions));
         error = string.Empty;
         return true;
     }
@@ -145,13 +160,18 @@ public sealed class LinkContainer : List<DesignLink>
     public bool Remove(Design child)
         => Before.RemoveAll(l => l.Link == child) + After.RemoveAll(l => l.Link == child) > 0;
 
-    public static IEnumerable<(DesignLink Link, LinkOrder Order)> GetAllLinks(Design design)
+    public static IEnumerable<(DesignLink Link, LinkOrder Order)> GetAllLinks(Design design, Predicate<DesignConditions>? condition)
     {
+        var self = new DesignLink(design, ApplicationType.All, DesignConditions.AlwaysTrue);
+        if (condition is not null && !condition(self.Conditions))
+            return [];
+
         var set = new HashSet<Design>(design.Links.Count * 4);
-        return GetAllLinks(new DesignLink(design, ApplicationType.All), LinkOrder.Self, set);
+        return GetAllLinks(self, condition, LinkOrder.Self, set);
     }
 
-    private static IEnumerable<(DesignLink Link, LinkOrder Order)> GetAllLinks(DesignLink design, LinkOrder currentOrder, ISet<Design> visited)
+    private static IEnumerable<(DesignLink Link, LinkOrder Order)> GetAllLinks(DesignLink design, Predicate<DesignConditions>? condition,
+        LinkOrder currentOrder, ISet<Design> visited)
     {
         if (design.Link.Links.Count == 0)
         {
@@ -162,15 +182,17 @@ public sealed class LinkContainer : List<DesignLink>
         }
 
         foreach (var link in design.Link.Links.Before
-                     .Where(l => !visited.Contains(l.Link))
-                     .SelectMany(l => GetAllLinks(l, currentOrder == LinkOrder.After ? LinkOrder.After : LinkOrder.Before, visited)))
+                     .Where(l => (condition is null || condition(l.Conditions)) && !visited.Contains(l.Link))
+                     .SelectMany(l => GetAllLinks(l, condition, currentOrder == LinkOrder.After ? LinkOrder.After : LinkOrder.Before, visited)))
             yield return link;
 
         if (visited.Add(design.Link))
             yield return (design, currentOrder);
 
-        foreach (var link in design.Link.Links.After.Where(l => !visited.Contains(l.Link))
-                     .SelectMany(l => GetAllLinks(l, currentOrder == LinkOrder.Before ? LinkOrder.Before : LinkOrder.After, visited)))
+        foreach (var link in design.Link.Links.After
+                     .Where(l => (condition is null || condition(l.Conditions)) && !visited.Contains(l.Link))
+                     .SelectMany(l => GetAllLinks(l, condition, currentOrder == LinkOrder.Before ? LinkOrder.Before : LinkOrder.After,
+                         visited)))
             yield return link;
     }
 
@@ -181,8 +203,9 @@ public sealed class LinkContainer : List<DesignLink>
         {
             before.Add(new JObject
             {
-                ["Design"] = link.Link.Identifier,
-                ["Type"]   = (uint)link.Type,
+                ["Design"]     = link.Link.Identifier,
+                ["Type"]       = (uint)link.Type,
+                ["Conditions"] = link.Conditions.Data.Serialize(),
             });
         }
 
@@ -191,8 +214,9 @@ public sealed class LinkContainer : List<DesignLink>
         {
             after.Add(new JObject
             {
-                ["Design"] = link.Link.Identifier,
-                ["Type"]   = (uint)link.Type,
+                ["Design"]     = link.Link.Identifier,
+                ["Type"]       = (uint)link.Type,
+                ["Conditions"] = link.Conditions.Data.Serialize(),
             });
         }
 

--- a/Glamourer/Designs/Special/QuickSelectedDesign.cs
+++ b/Glamourer/Designs/Special/QuickSelectedDesign.cs
@@ -39,8 +39,9 @@ public class QuickSelectedDesign(QuickDesignCombo combo) : IDesignStandIn, IServ
     public StateSource AssociatedSource()
         => StateSource.Manual;
 
-    public IEnumerable<(IDesignStandIn Design, ApplicationType Flags, JobFlag Jobs)> AllLinks(bool newApplication)
-        => combo.QuickDesign?.AllLinks(newApplication) ?? [];
+    public IEnumerable<(IDesignStandIn Design, ApplicationType Flags, JobFlag Jobs)> AllLinks(bool newApplication,
+        Predicate<DesignConditions>? condition)
+        => combo.QuickDesign?.AllLinks(newApplication, condition) ?? [];
 
     public void AddData(JObject jObj)
     { }

--- a/Glamourer/Designs/Special/RandomDesign.cs
+++ b/Glamourer/Designs/Special/RandomDesign.cs
@@ -48,7 +48,8 @@ public class RandomDesign(RandomDesignGenerator rng) : IDesignStandIn
     public StateSource AssociatedSource()
         => StateSource.Manual;
 
-    public IEnumerable<(IDesignStandIn Design, ApplicationType Flags, JobFlag Jobs)> AllLinks(bool newApplication)
+    public IEnumerable<(IDesignStandIn Design, ApplicationType Flags, JobFlag Jobs)> AllLinks(bool newApplication,
+        Predicate<DesignConditions>? condition)
     {
         if (newApplication || ResetOnRedraw)
             _currentDesign = rng.Design(Predicates);
@@ -57,7 +58,7 @@ public class RandomDesign(RandomDesignGenerator rng) : IDesignStandIn
         if (_currentDesign == null)
             yield break;
 
-        foreach (var (link, type, jobs) in _currentDesign.AllLinks(newApplication))
+        foreach (var (link, type, jobs) in _currentDesign.AllLinks(newApplication, condition))
             yield return (link, type, jobs);
     }
 

--- a/Glamourer/Designs/Special/RevertDesign.cs
+++ b/Glamourer/Designs/Special/RevertDesign.cs
@@ -29,7 +29,7 @@ public class RevertDesign : IDesignStandIn
     public StateSource AssociatedSource()
         => StateSource.Game;
 
-    public IEnumerable<(IDesignStandIn Design, ApplicationType Flags, JobFlag Jobs)> AllLinks(bool _)
+    public IEnumerable<(IDesignStandIn Design, ApplicationType Flags, JobFlag Jobs)> AllLinks(bool _, Predicate<DesignConditions>? _2)
     {
         yield return (this, ApplicationType.All, JobFlag.All);
     }

--- a/Glamourer/Events/AutomationChanged.cs
+++ b/Glamourer/Events/AutomationChanged.cs
@@ -170,11 +170,11 @@ public sealed class AutomationChanged(LunaLogger log)
     public sealed record ChangedDesignArguments(AutoDesignSet Set, int DesignIndex, IDesignStandIn OldDesign, IDesignStandIn NewDesign)
         : Arguments(Type.ChangedDesign, Set);
 
-    /// <param name="Set"> The set that changed a job group condition. </param>
+    /// <param name="Set"> The set that changed a condition. </param>
     /// <param name="DesignIndex"> The index of the changed design. </param>
-    /// <param name="OldGroup"> The prior job condition for the design. </param>
-    /// <param name="NewGroup"> The new job condition for the design. </param>
-    public sealed record ChangedConditionsArguments(AutoDesignSet Set, int DesignIndex, JobGroup OldGroup, JobGroup NewGroup)
+    /// <param name="Old"> The prior conditions for the design. </param>
+    /// <param name="New"> The new conditions for the design. </param>
+    public sealed record ChangedConditionsArguments(AutoDesignSet Set, int DesignIndex, DesignConditions Old, DesignConditions New)
         : Arguments(Type.ChangedConditions, Set);
 
     /// <param name="Set"> The set that changed its application type. </param>

--- a/Glamourer/Gui/Tabs/AutomationTab/AutoDesignCacheItem.cs
+++ b/Glamourer/Gui/Tabs/AutomationTab/AutoDesignCacheItem.cs
@@ -10,10 +10,9 @@ public readonly struct AutoDesignCacheItem(AutoDesignSet set, AutoDesign design,
     public readonly StringU8      Name            = new(design.Design.ResolveName(false));
     public readonly StringU8      Incognito       = new(design.Design.ResolveName(true));
     public readonly StringU8      IndexU8         = new($"#{index + 1:D2}");
-    public readonly StringU8      JobRestrictions = design.GearsetIndex is -1 ? design.Jobs.Name : StringU8.Empty;
+    public readonly StringU8      JobRestrictions = design.Conditions.ToJobsRestrictionString();
 
-    public readonly StringU8 GearSetRestriction =
-        set.Designs[index].GearsetIndex is -1 ? StringU8.Empty : new StringU8($"{design.GearsetIndex}");
+    public readonly StringU8 GearSetRestriction = design.Conditions.ToGearSetRestrictionString();
 
     public readonly int  Index    = index;
     public readonly bool Disabled = design.Type is 0;

--- a/Glamourer/Gui/Tabs/AutomationTab/AutomationTestWindow.cs
+++ b/Glamourer/Gui/Tabs/AutomationTab/AutomationTestWindow.cs
@@ -13,7 +13,7 @@ namespace Glamourer.Gui.Tabs.AutomationTab;
 public sealed class AutomationTestWindow : Window, IDisposable
 {
     private readonly JobCombo            _jobCombo;
-    private          int                 _gearSet = -1;
+    private          short               _gearSet = -1;
     private          Job?                _job;
     private readonly AutomationChanged   _changed;
     private readonly AutomationSelection _selection;

--- a/Glamourer/Gui/Tabs/AutomationTab/SetPanel.cs
+++ b/Glamourer/Gui/Tabs/AutomationTab/SetPanel.cs
@@ -7,6 +7,7 @@ using Glamourer.Services;
 using Glamourer.Unlocks;
 using Glamourer.Config;
 using Glamourer.Events;
+using Glamourer.Gui.Tabs.DesignTab;
 using ImSharp;
 using Luna;
 using Penumbra.GameData.Actors;
@@ -20,7 +21,7 @@ namespace Glamourer.Gui.Tabs.AutomationTab;
 
 public sealed class SetPanel(
     AutoDesignManager manager,
-    JobService jobs,
+    DesignConditionsDrawer conditionsDrawer,
     ItemUnlockManager itemUnlocks,
     SpecialDesignCombo designCombo,
     CustomizeUnlockManager customizeUnlocks,
@@ -35,7 +36,6 @@ public sealed class SetPanel(
 {
     private readonly AutomationSelection _selection         = selection;
     private readonly AutomationChanged   _automationChanged = automationChanged;
-    private readonly JobGroupCombo       _jobGroupCombo     = new(manager, jobs);
 
     private readonly AutoDesignNameFilter    _nameFilter    = new(config);
     private readonly AutoDesignJobFilter     _jobFilter     = new(config);
@@ -284,7 +284,7 @@ public sealed class SetPanel(
         var sb        = new StringBuilder();
         if (cacheItem.Design.Design is Design d)
         {
-            var count = d.AllLinks(true).Count();
+            var count = d.AllLinks(true, null).Count();
             if (count > 1)
             {
                 sb.AppendLine($"This design contains {count - 1} links to other designs.");
@@ -318,26 +318,8 @@ public sealed class SetPanel(
 
     private void DrawConditions(in AutoDesignCacheItem item)
     {
-        var usingGearset = item.Design.GearsetIndex >= 0;
-        if (Im.Button(usingGearset ? "Gearset:##usingGearset"u8 : "Jobs:##usingGearset"u8))
-        {
-            usingGearset = !usingGearset;
-            manager.ChangeGearsetCondition(item.Set, item.Index, (short)(usingGearset ? 0 : -1));
-        }
-
-        Im.Tooltip.OnHover("Click to switch between Job and Gearset restrictions."u8);
-
-        Im.Line.SameInner();
-        if (usingGearset)
-        {
-            Im.Item.SetNextWidthFull();
-            if (ImEx.InputOnDeactivation.Scalar("##whichGearset"u8, item.Design.GearsetIndex + 1, out var newIndex))
-                manager.ChangeGearsetCondition(item.Set, item.Index, (short)(Math.Clamp(newIndex, 1, 100) - 1));
-        }
-        else
-        {
-            _jobGroupCombo.Draw(item.Set, item.Design, item.Index);
-        }
+        if (conditionsDrawer.Draw(in item.Design.Conditions, out var newConditions))
+            manager.ChangeConditions(item.Set, item.Index, newConditions);
     }
 
     private void DrawRandomEditing(AutoDesignSet set, AutoDesign design, int designIdx)
@@ -602,29 +584,6 @@ public sealed class SetPanel(
         }
 
         return contained;
-    }
-
-    private sealed class JobGroupCombo(AutoDesignManager manager, JobService jobs)
-        : SimpleFilterCombo<JobGroup>(SimpleFilterType.Partwise)
-    {
-        public void Draw(AutoDesignSet set, AutoDesign design, int autoDesignIndex)
-        {
-            if (Draw("##jobGroups"u8, design.Jobs,
-                    "Select for which job groups this design should be applied.\nControl + Right-Click to set to all classes."u8,
-                    Im.ContentRegion.Available.X, out var newGroup))
-                manager.ChangeJobCondition(set, autoDesignIndex, newGroup);
-            else if (Im.Io.KeyControl && Im.Item.RightClicked())
-                manager.ChangeJobCondition(set, autoDesignIndex, jobs.JobGroups[1]);
-        }
-
-        public override StringU8 DisplayString(in JobGroup value)
-            => value.Name;
-
-        public override string FilterString(in JobGroup value)
-            => value.Name.ToString();
-
-        public override IEnumerable<JobGroup> GetBaseItems()
-            => jobs.JobGroups.Values;
     }
 
 

--- a/Glamourer/Gui/Tabs/DebugTab/AutoDesignPanel.cs
+++ b/Glamourer/Gui/Tabs/DebugTab/AutoDesignPanel.cs
@@ -33,7 +33,7 @@ public sealed class AutoDesignPanel(AutoDesignManager autoDesignManager) : IGame
             foreach (var (designIdx, design) in set.Designs.Index())
             {
                 table.DrawColumn($"{design.Design.ResolveName(false)} ({designIdx})");
-                table.DrawColumn($"{design.Type} {design.Jobs.Name}");
+                table.DrawColumn($"{design.Type} {design.Conditions}");
             }
         }
     }

--- a/Glamourer/Gui/Tabs/DesignTab/DesignConditionsDrawer.cs
+++ b/Glamourer/Gui/Tabs/DesignTab/DesignConditionsDrawer.cs
@@ -1,0 +1,78 @@
+using Glamourer.Designs;
+using Glamourer.Interop;
+using ImSharp;
+using Luna;
+using Penumbra.GameData.Structs;
+
+namespace Glamourer.Gui.Tabs.DesignTab;
+
+public class DesignConditionsDrawer(JobService jobs) : IService
+{
+    private readonly JobGroupCombo _jobGroupCombo = new(jobs);
+
+    public bool Draw(in DesignConditions conditions, out DesignConditions newConditions)
+    {
+        newConditions = conditions;
+        var changed      = false;
+        var usingGearset = conditions.GearsetIndex >= 0;
+        if (Im.Button(usingGearset ? "Gearset:##usingGearset"u8 : "Jobs:##usingGearset"u8))
+        {
+            usingGearset  = !usingGearset;
+            newConditions = conditions with { GearsetIndex = (short)(usingGearset ? 0 : -1) };
+            changed       = true;
+        }
+
+        Im.Tooltip.OnHover("Click to switch between Job and Gearset restrictions."u8);
+
+        Im.Line.SameInner();
+        if (usingGearset)
+        {
+            Im.Item.SetNextWidthFull();
+            if (ImEx.InputOnDeactivation.Scalar("##whichGearset"u8, conditions.GearsetIndex + 1, out var newIndex))
+            {
+                newConditions = conditions with { GearsetIndex = (short)(Math.Clamp(newIndex, 1, 100) - 1) };
+                changed       = true;
+            }
+        }
+        else
+        {
+            if (_jobGroupCombo.Draw(conditions.Jobs, out var newJobs))
+            {
+                newConditions = conditions with { Jobs = newJobs };
+                changed       = true;
+            }
+        }
+
+        return changed;
+    }
+
+    private sealed class JobGroupCombo(JobService jobs)
+        : SimpleFilterCombo<JobGroup>(SimpleFilterType.Partwise)
+    {
+        public bool Draw(in JobGroup jobGroup, out JobGroup newGroup)
+        {
+            if (Draw("##jobGroups"u8, in jobGroup,
+                    "Select for which job groups this design should be applied.\nControl + Right-Click to set to all classes."u8,
+                    Im.ContentRegion.Available.X, out newGroup))
+                return true;
+
+            if (Im.Io.KeyControl && Im.Item.RightClicked())
+            {
+                newGroup = jobs.JobGroups[1];
+                return true;
+            }
+
+            newGroup = jobGroup;
+            return false;
+        }
+
+        public override StringU8 DisplayString(in JobGroup value)
+            => value.Name;
+
+        public override string FilterString(in JobGroup value)
+            => value.Name.ToString();
+
+        public override IEnumerable<JobGroup> GetBaseItems()
+            => jobs.JobGroups.Values;
+    }
+}

--- a/Glamourer/Gui/Tabs/DesignTab/DesignLinkDrawer.cs
+++ b/Glamourer/Gui/Tabs/DesignTab/DesignLinkDrawer.cs
@@ -13,6 +13,7 @@ public class DesignLinkDrawer(
     DesignFileSystem fileSystem,
     LinkDesignCombo combo,
     DesignColors colorManager,
+    DesignConditionsDrawer conditionsDrawer,
     Configuration config) : IUiService
 {
     private int       _dragDropIndex       = -1;
@@ -74,19 +75,38 @@ public class DesignLinkDrawer(
 
     private void DrawList()
     {
+        const float singleRowMinNameWidth       = 220.0f;
+        const float singleRowMinConditionsWidth = 150.0f;
+        const float singleRowMaxConditionsWidth = 300.0f;
+
+        const float singleRowMinSpareWidth = singleRowMinNameWidth + singleRowMinConditionsWidth;
+        
         using var table = Im.Table.Begin("table"u8, 3, TableFlags.RowBackground | TableFlags.BordersOuter);
         if (!table)
             return;
 
+        var applicationBoxesWidth = 6 * Im.Style.FrameHeight + 5 * Im.Style.ItemInnerSpacing.X;
+        var spareWidth = (Im.ContentRegion.Available.X
+              - Im.Style.CellPadding.X * 6
+              - Im.Style.FrameHeight
+              - applicationBoxesWidth
+              - Im.Style.ItemSpacing.X)
+          / Im.Style.GlobalScale;
+        var singleRow = spareWidth >= singleRowMinSpareWidth;
+
         table.SetupColumn("Del"u8,  TableColumnFlags.WidthFixed, Im.Style.FrameHeight);
         table.SetupColumn("Name"u8, TableColumnFlags.WidthStretch);
-        table.SetupColumn("Detail"u8, TableColumnFlags.WidthFixed,
-            6 * Im.Style.FrameHeight + 5 * Im.Style.ItemInnerSpacing.X);
+        table.SetupColumn("Detail"u8, TableColumnFlags.WidthFixed, singleRow
+            ? applicationBoxesWidth
+          + Im.Style.ItemSpacing.X
+          + MathF.Min(singleRowMinConditionsWidth + (spareWidth - singleRowMinSpareWidth) * 0.5f, singleRowMaxConditionsWidth)
+          * Im.Style.GlobalScale
+            : 3 * Im.Style.FrameHeight + 2 * Im.Style.ItemInnerSpacing.X);
 
         using var style = ImStyleDouble.ItemSpacing.Push(Im.Style.ItemInnerSpacing);
-        DrawSubList(table, Selected.Links.Before, LinkOrder.Before);
+        DrawSubList(table, Selected.Links.Before, LinkOrder.Before, singleRow);
         DrawSelf(table);
-        DrawSubList(table, Selected.Links.After, LinkOrder.After);
+        DrawSubList(table, Selected.Links.After, LinkOrder.After, singleRow);
         DrawNew(table);
         MoveLink();
     }
@@ -121,7 +141,7 @@ public class DesignLinkDrawer(
         }
     }
 
-    private void DrawSubList(in Im.TableDisposable table, IReadOnlyList<DesignLink> list, LinkOrder order)
+    private void DrawSubList(in Im.TableDisposable table, IReadOnlyList<DesignLink> list, LinkOrder order, bool singleRow)
     {
         using var id = Im.Id.Push((int)order);
 
@@ -131,7 +151,7 @@ public class DesignLinkDrawer(
 
             table.NextColumn();
             var delete = ImEx.Icon.Button(LunaStyle.DeleteIcon, "Delete this link."u8);
-            var (design, flags) = list[i];
+            var (design, flags, conditions) = list[i];
             table.NextColumn();
 
             using (ImGuiColor.Text.Push(colorManager.GetColor(design)))
@@ -141,10 +161,17 @@ public class DesignLinkDrawer(
             }
 
             DrawDragDrop(design, order, i);
+            if (!singleRow)
+                DrawConditions(i, order, in conditions);
 
             table.NextColumn();
             Im.Cursor.FrameAlign();
-            DrawApplicationBoxes(i, order, flags);
+            DrawApplicationBoxes(i, order, flags, singleRow);
+            if (singleRow)
+            {
+                Im.Line.Same();
+                DrawConditions(i, order, in conditions);
+            }
 
             if (delete)
                 linkManager.RemoveDesignLink(Selected, i--, order);
@@ -209,7 +236,7 @@ public class DesignLinkDrawer(
         _dragDropTargetOrder = order;
     }
 
-    private void DrawApplicationBoxes(int idx, LinkOrder order, ApplicationType current)
+    private void DrawApplicationBoxes(int idx, LinkOrder order, ApplicationType current, bool singleRow)
     {
         var newType = current;
         using (ImStyleBorder.Frame.Push(ColorId.FolderLine.Value()))
@@ -223,7 +250,8 @@ public class DesignLinkDrawer(
         Box(0);
         Im.Line.Same();
         Box(1);
-        Im.Line.Same();
+        if (singleRow)
+            Im.Line.Same();
 
         Box(2);
         Im.Line.Same();
@@ -243,5 +271,11 @@ public class DesignLinkDrawer(
                 newType = value ? newType | applicationType : newType & ~applicationType;
             Im.Tooltip.OnHover(applicationType.Tooltip());
         }
+    }
+
+    private void DrawConditions(int idx, LinkOrder order, in DesignConditions current)
+    {
+        if (conditionsDrawer.Draw(in current, out var newConditions))
+            linkManager.ChangeConditions(Selected, idx, order, newConditions);
     }
 }

--- a/Glamourer/State/StateEditor.cs
+++ b/Glamourer/State/StateEditor.cs
@@ -8,6 +8,7 @@ using Glamourer.GameData;
 using Glamourer.Interop.Material;
 using Glamourer.Interop.Penumbra;
 using Glamourer.Services;
+using Luna;
 using Penumbra.GameData.Enums;
 using Penumbra.GameData.Interop;
 using Penumbra.GameData.Structs;
@@ -457,8 +458,8 @@ public class StateEditor(
         if (!settings.MergeLinks || design is not Design d)
             merged = new MergedDesign(design);
         else
-            merged = merger.Merge(d.AllLinks(true), state.ModelData.IsHuman ? state.ModelData.Customize : CustomizeArray.Default,
-                state.BaseData,
+            merged = merger.Merge(d.AllLinks(true, ActorConditions(state)),
+                state.ModelData.IsHuman ? state.ModelData.Customize : CustomizeArray.Default, state.BaseData,
                 false, Config.AlwaysApplyAssociatedMods);
 
         ApplyDesign(data, merged, settings with
@@ -468,6 +469,11 @@ public class StateEditor(
             UseSingleSource = true,
         });
     }
+
+    private Predicate<DesignConditions>? ActorConditions(ActorState state)
+        => Applier.GetData(state).Objects.FindFirst(static actor => actor.IsCharacter, out var actor)
+            ? cond => cond.Match(actor)
+            : null;
 
 
     /// <summary> Apply offhand item and potentially gauntlets if configured. </summary>


### PR DESCRIPTION
This allows, for example, to have a single entry in the QDB that applies a general design, and then a colorway (through dyes, advanced dyes, mod associations or what not) that depends on job, role, gearset or any criterion that can be used for automations.