### PR TITLE
Fix Reset Advanced Dyes when set to only some slots

### DIFF
--- a/Glamourer/Interop/Material/MaterialValueManager.cs
+++ b/Glamourer/Interop/Material/MaterialValueManager.cs
@@ -537,7 +537,7 @@ public readonly struct MaterialValueManager<T>
         if (minIdx < 0)
             return 0;
 
-        var count = maxIdx - minIdx;
+        var count = maxIdx + 1 - minIdx;
         _values.RemoveRange(minIdx, count);
         return count;
     }


### PR DESCRIPTION
`MaterialValueManager.Filter` uses `values[minIdx..(maxIdx + 1)]`.

This makes it so `MaterialValueManager<T>.RemoveValues` removes the same range.