### PR TITLE
Fixes advanced dyes not clearing from IPC.

### DIFF
--- a/Glamourer/State/StateEditor.cs
+++ b/Glamourer/State/StateEditor.cs
@@ -407,7 +407,7 @@ public class StateEditor(
 
             if (settings.ResetMaterials || !settings.RespectManual && mergedDesign.ResetAdvancedDyes is not 0)
             {
-                if (mergedDesign.ResetAdvancedDyes.HasFlag(EquipFlagExtensions.AllCombined))
+                if (settings.ResetMaterials || mergedDesign.ResetAdvancedDyes.HasFlag(EquipFlagExtensions.AllCombined))
                     state.Materials.Clear();
                 else
                 {


### PR DESCRIPTION
Prior to a35ede7, setting `settings.ResetMaterials` (as is done when applying state via IPC) would clear the materials regardless of whether `mergedDesign.ResetAdvancedDyes` was set or not . That commit changed the behavior so that setting `settings.ResetMaterials` without `mergedDesign.ResetAdvancedDyes` has no effect, breaking sync services' behavior when someone had advanced dyes and then removes them. This commit restores the old functionality that a35ede7 removed (I believe accidentally).