### PR TITLE
Add an editor to configure an associated mod's option settings.

### DIFF
--- a/Glamourer/Config/Configuration.cs
+++ b/Glamourer/Config/Configuration.cs
@@ -46,6 +46,7 @@ public sealed partial class Configuration : IPluginConfiguration, ISavable, ISer
     public bool            OpenWindowAtStart                { get; set; } = false;
     public bool            ShowWindowWhenUiHidden           { get; set; } = false;
     public bool            KeepAdvancedDyesAttached         { get; set; } = true;
+    public bool            KeepModSettingsAttached          { get; set; } = true;
     public bool            ShowPalettePlusImport            { get; set; } = true;
     public bool            UseFloatForColors                { get; set; } = true;
     public bool            UseRgbForColors                  { get; set; } = true;

--- a/Glamourer/Gui/Tabs/DesignTab/ModAssociationSettingsPopup.cs
+++ b/Glamourer/Gui/Tabs/DesignTab/ModAssociationSettingsPopup.cs
@@ -1,0 +1,239 @@
+using Dalamud.Interface;
+using Dalamud.Interface.ImGuiNotification;
+using Glamourer.Config;
+using Glamourer.Designs;
+using Glamourer.Interop.Penumbra;
+using Glamourer.State;
+using ImSharp;
+using Luna;
+using Penumbra.Api.Enums;
+
+namespace Glamourer.Gui.Tabs.DesignTab;
+
+/// <summary>
+/// A side window, modelled after the advanced dye editor, that lets the user configure the
+/// Penumbra option-group selections stored in a design's mod association. Changes are persisted
+/// to the design and applied to Penumbra as temporary settings (live preview).
+/// </summary>
+public sealed class ModAssociationSettingsPopup(PenumbraService penumbra, DesignManager manager, Configuration config) : IService
+{
+    public static readonly AwesomeIcon EditIcon = LunaStyle.EditIcon;
+
+    private Design?     _design;
+    private Mod?        _mod;
+    private ModSettings _settings = ModSettings.Empty;
+    private IReadOnlyDictionary<string, (string[] Options, GroupType Type)>? _groups;
+    private bool        _forceFocus;
+
+    /// <summary> Draw the toggle button that opens/closes the settings window for a given association row. </summary>
+    public void DrawButton(Design design, Mod mod, ModSettings settings)
+    {
+        var isOpen = _mod == mod && ReferenceEquals(_design, design);
+        using (ImStyleBorder.Frame.Push(ColorId.HeaderButtons.Value(), 2 * Im.Style.GlobalScale, isOpen))
+        {
+            if (ImEx.Icon.Button(EditIcon, "Configure this mod's option settings and apply them to Penumbra temporarily."u8,
+                    !penumbra.Available))
+            {
+                if (isOpen)
+                    Close();
+                else
+                    Open(design, mod, settings);
+            }
+        }
+    }
+
+    /// <summary> Draw the window itself if it is open. Closes automatically if the selected design changed. </summary>
+    public void Draw(Design currentDesign)
+    {
+        if (_mod is not { } mod || _design is null)
+            return;
+
+        if (!ReferenceEquals(_design, currentDesign) || !penumbra.Available)
+        {
+            Close();
+            return;
+        }
+
+        DrawWindow(mod);
+    }
+
+    private void Open(Design design, Mod mod, ModSettings settings)
+    {
+        _design = design;
+        _mod    = mod;
+        _groups = penumbra.GetAvailableSettings(mod);
+
+        // Baseline the working copy from the mod's current effective selections in Penumbra, so that
+        // groups the design does not explicitly store still show their real state (as in Penumbra's own
+        // panel). The design's stored selections are then overlaid on top and take precedence.
+        var merged = new Dictionary<string, List<string>>();
+        var live   = penumbra.GetModSettings(mod, out _);
+        foreach (var (group, options) in live.Settings)
+            merged[group] = [.. options];
+        foreach (var (group, options) in settings.Settings)
+            merged[group] = [.. options];
+
+        _settings   = settings with { Settings = merged };
+        _forceFocus = true;
+    }
+
+    private void Close()
+    {
+        _design   = null;
+        _mod      = null;
+        _groups   = null;
+        _settings = ModSettings.Empty;
+    }
+
+    private void DrawWindow(Mod mod)
+    {
+        var flags = WindowFlags.NoFocusOnAppearing
+          | WindowFlags.NoCollapse
+          | WindowFlags.NoDocking;
+
+        var parentPos  = Im.Window.Position;
+        var parentSize = Im.Window.Size;
+        var width      = 320 * Im.Style.GlobalScale;
+
+        if (config.KeepModSettingsAttached)
+        {
+            // Dock to the right of the main window and lock it in place.
+            Im.Window.SetNextPosition(new Vector2(parentPos.X + parentSize.X + Im.Style.WindowPadding.X, parentPos.Y));
+            Im.Window.SetNextSize(new Vector2(width, parentSize.Y));
+            flags |= WindowFlags.NoMove;
+        }
+        else
+        {
+            // Free-floating: only size/position it on first appearance, then let the user move it.
+            Im.Window.SetNextSize(new Vector2(width, parentSize.Y), Condition.FirstUseEver);
+        }
+
+        using var window = Im.Window.Begin("Mod Settings###GlamourerModAssociationSettings"u8, flags);
+        if (Im.Window.Appearing || _forceFocus)
+        {
+            Im.Window.SetFocus("###GlamourerModAssociationSettings"u8);
+            _forceFocus = false;
+        }
+
+        if (window)
+            DrawContent(mod);
+    }
+
+    private void DrawContent(Mod mod)
+    {
+        if (ImEx.Icon.Button(LunaStyle.CancelIcon, "Close this window."u8))
+        {
+            Close();
+            return;
+        }
+
+        Im.Line.Same();
+        ImEx.TextFrameAligned(mod.Name);
+        Im.Tooltip.OnHover($"Mod Directory:    {mod.DirectoryName}");
+        Im.Separator();
+
+        if (_groups is null)
+        {
+            Im.Text("Could not read this mod's options from Penumbra (is it still installed?)."u8);
+            return;
+        }
+
+        if (_groups.Count is 0)
+        {
+            Im.Text("This mod has no configurable option groups."u8);
+            return;
+        }
+
+        var idx = 0;
+        foreach (var (groupName, (options, type)) in _groups)
+        {
+            using var id = Im.Id.Push(idx++);
+            DrawGroup(mod, groupName, options, type);
+            Im.Separator();
+        }
+    }
+
+    private void DrawGroup(Mod mod, string groupName, string[] options, GroupType type)
+    {
+        switch (type)
+        {
+            case GroupType.Single:
+                DrawSingleGroup(mod, groupName, options);
+                break;
+            case GroupType.Multi:
+            case GroupType.Imc:
+            case GroupType.Combining:
+                DrawMultiGroup(mod, groupName, options);
+                break;
+            default:
+                DrawComplexGroup(groupName);
+                break;
+        }
+    }
+
+    private void DrawSingleGroup(Mod mod, string groupName, string[] options)
+    {
+        _settings.Settings.TryGetValue(groupName, out var selected);
+        var current = selected is { Count: > 0 } ? selected[0] : string.Empty;
+
+        ImEx.TextFrameAligned(groupName);
+        Im.Item.SetNextWidthFull();
+        using var combo = Im.Combo.Begin($"##{groupName}", current.Length > 0 ? current : "<Default>");
+        if (!combo)
+            return;
+
+        foreach (var option in options)
+        {
+            if (Im.Selectable(option, option == current) && option != current)
+            {
+                _settings.Settings[groupName] = [option];
+                Commit(mod);
+            }
+        }
+    }
+
+    private void DrawMultiGroup(Mod mod, string groupName, string[] options)
+    {
+        ImEx.TextFrameAligned(groupName);
+        if (!_settings.Settings.TryGetValue(groupName, out var selected))
+        {
+            selected                      = [];
+            _settings.Settings[groupName] = selected;
+        }
+
+        using var indent = Im.Indent();
+        foreach (var option in options)
+        {
+            var enabled = selected.Contains(option);
+            if (!Im.Checkbox(option, ref enabled))
+                continue;
+
+            if (enabled)
+                selected.Add(option);
+            else
+                selected.Remove(option);
+            Commit(mod);
+        }
+    }
+
+    private void DrawComplexGroup(string groupName)
+    {
+        _settings.Settings.TryGetValue(groupName, out var selected);
+        var value = selected is { Count: > 0 } ? string.Join(", ", selected) : "<Default>";
+        ImEx.TextFrameAligned($"{groupName}: {value}");
+        Im.Tooltip.OnHover(
+            "This group uses an advanced type (Combining/Complex) that can't be edited here yet.\nConfigure it in Penumbra, then use the Refresh button on the association row to capture it."u8);
+    }
+
+    /// <summary> Persist the current working settings to the design and live-apply them to Penumbra. </summary>
+    private void Commit(Mod mod)
+    {
+        if (_design is null)
+            return;
+
+        manager.UpdateMod(_design, mod, _settings);
+        var text = penumbra.SetMod(mod, _settings, StateSource.Manual, false);
+        if (text.Length > 0)
+            Glamourer.Messager.NotificationMessage(text, NotificationType.Warning, false);
+    }
+}

--- a/Glamourer/Gui/Tabs/DesignTab/ModAssociationsTab.cs
+++ b/Glamourer/Gui/Tabs/DesignTab/ModAssociationsTab.cs
@@ -8,7 +8,12 @@ using Luna;
 
 namespace Glamourer.Gui.Tabs.DesignTab;
 
-public sealed class ModAssociationsTab(PenumbraService penumbra, DesignFileSystem fileSystem, DesignManager manager, Configuration config) : IUiService
+public sealed class ModAssociationsTab(
+    PenumbraService penumbra,
+    DesignFileSystem fileSystem,
+    DesignManager manager,
+    Configuration config,
+    ModAssociationSettingsPopup settingsPopup) : IUiService
 {
     private readonly ModCombo              _modCombo = new(penumbra, fileSystem);
     private          (Mod, ModSettings)[]? _copy;
@@ -33,6 +38,7 @@ public sealed class ModAssociationsTab(PenumbraService penumbra, DesignFileSyste
         DrawApplyAllButton();
         DrawTable();
         DrawCopyButtons();
+        settingsPopup.Draw(Selection);
     }
 
     private void DrawCopyButtons()
@@ -95,7 +101,7 @@ public sealed class ModAssociationsTab(PenumbraService penumbra, DesignFileSyste
         if (!table)
             return;
 
-        table.SetupColumn("##Buttons"u8, TableColumnFlags.WidthFixed, Im.Style.FrameHeight * 3 + Im.Style.ItemInnerSpacing.X * 2);
+        table.SetupColumn("##Buttons"u8, TableColumnFlags.WidthFixed, Im.Style.FrameHeight * 4 + Im.Style.ItemInnerSpacing.X * 3);
         table.SetupColumn("Mod Name"u8,  TableColumnFlags.WidthStretch);
         if (config.UseTemporarySettings)
             table.SetupColumn("Remove"u8, TableColumnFlags.WidthFixed, Im.Font.CalculateSize("Remove"u8).X);
@@ -179,6 +185,9 @@ public sealed class ModAssociationsTab(PenumbraService penumbra, DesignFileSyste
                 ModCombo.DrawSettingsRight(newSettings);
             }
         }
+
+        Im.Line.SameInner();
+        settingsPopup.DrawButton(Selection, mod, settings);
 
         table.NextColumn();
 

--- a/Glamourer/Gui/Tabs/SettingsTab/SettingsTab.cs
+++ b/Glamourer/Gui/Tabs/SettingsTab/SettingsTab.cs
@@ -335,6 +335,10 @@ public sealed class SettingsTab(
             "Keeps the advanced dye window expansion attached to the main window, or makes it freely movable."u8,
             config.KeepAdvancedDyesAttached, v => config.KeepAdvancedDyesAttached = v);
 
+        Checkbox("Keep Mod Settings Window Attached"u8,
+            "Keeps the associated-mod settings editor attached to the main window, or makes it freely movable."u8,
+            config.KeepModSettingsAttached, v => config.KeepModSettingsAttached = v);
+
         Checkbox("Debug Mode"u8, "Show the debug tab. Only useful for debugging or advanced use. Not recommended in general."u8,
             config.DebugMode,
             v => config.DebugMode = v);

--- a/Glamourer/Interop/Penumbra/PenumbraService.cs
+++ b/Glamourer/Interop/Penumbra/PenumbraService.cs
@@ -72,6 +72,7 @@ public sealed class PenumbraService : IDisposable, IService
     private global::Penumbra.Api.IpcSubscribers.RedrawObject?                                        _redraw;
     private global::Penumbra.Api.IpcSubscribers.GetCollectionForObject?                              _objectCollection;
     private global::Penumbra.Api.IpcSubscribers.GetModList?                                          _getMods;
+    private global::Penumbra.Api.IpcSubscribers.GetAvailableModSettings?                             _getAvailableSettings;
     private global::Penumbra.Api.IpcSubscribers.GetCollection?                                       _currentCollection;
     private global::Penumbra.Api.IpcSubscribers.GetCurrentModSettingsWithTemp?                       _getCurrentSettingsWithTemp;
     private global::Penumbra.Api.IpcSubscribers.GetCurrentModSettings?                               _getCurrentSettings;
@@ -202,6 +203,26 @@ public sealed class PenumbraService : IDisposable, IService
         {
             Glamourer.Log.Error($"Error fetching mod settings for {mod.DirectoryName} from Penumbra:\n{ex}");
             return ModSettings.Empty;
+        }
+    }
+
+    /// <summary>
+    /// Obtain all configurable option groups of a mod, mapping each group name to its available options and its group type.
+    /// Returns null if Penumbra is unavailable or the mod could not be found.
+    /// </summary>
+    public IReadOnlyDictionary<string, (string[] Options, GroupType Type)>? GetAvailableSettings(in Mod mod)
+    {
+        if (!Available || _getAvailableSettings is null)
+            return null;
+
+        try
+        {
+            return _getAvailableSettings.Invoke(mod.DirectoryName, mod.Name);
+        }
+        catch (Exception ex)
+        {
+            Glamourer.Log.Error($"Error fetching available mod settings for {mod.DirectoryName} from Penumbra:\n{ex}");
+            return null;
         }
     }
 
@@ -579,6 +600,7 @@ public sealed class PenumbraService : IDisposable, IService
             _getGameObject = new global::Penumbra.Api.IpcSubscribers.GetGameObjectFromDrawObjectFunc(_pluginInterface).Invoke();
             _objectCollection = new global::Penumbra.Api.IpcSubscribers.GetCollectionForObject(_pluginInterface);
             _getMods = new global::Penumbra.Api.IpcSubscribers.GetModList(_pluginInterface);
+            _getAvailableSettings = new global::Penumbra.Api.IpcSubscribers.GetAvailableModSettings(_pluginInterface);
             _currentCollection = new global::Penumbra.Api.IpcSubscribers.GetCollection(_pluginInterface);
             _getCurrentSettings = new global::Penumbra.Api.IpcSubscribers.GetCurrentModSettings(_pluginInterface);
             _inheritMod = new global::Penumbra.Api.IpcSubscribers.TryInheritMod(_pluginInterface);
@@ -653,6 +675,7 @@ public sealed class PenumbraService : IDisposable, IService
             ResolveService.CheckCutsceneParent   = null;
             _objectCollection                    = null;
             _getMods                             = null;
+            _getAvailableSettings                = null;
             _currentCollection                   = null;
             _getCurrentSettings                  = null;
             _getCurrentSettingsWithTemp          = null;


### PR DESCRIPTION
# PR: Add an editor to configure an associated mod's option settings

**Title:** Add an editor to configure an associated mod's option settings.

**Base:** `Ottermandias/Glamourer:testing` ← **Head:** `fmieres:feature/mod-association-settings-editor`

---

## What

Adds an in-Glamourer editor for the Penumbra option settings stored in a design's **Mod Associations**. Until now an association could only override enabled / inherit / remove / priority; the option-group selections (Single/Multi choices) could only be captured wholesale from Penumbra's current state via the refresh button, never edited directly.

## How

- A new button on each Mod Association row opens a side window (modelled after the Advanced Dye editor) that renders the mod's option groups queried from Penumbra: a dropdown for **Single** groups and checkboxes for **Multi** groups. It docks to the right of the main window, honoring a new *Keep Mod Settings Window Attached* toggle (mirrors the advanced-dye one).
- The editor is pre-filled from the mod's current effective selections (`GetModSettings`), with the design's stored selections overlaid on top, so it reflects Penumbra's own panel.
- Edits are saved to the design and applied to Penumbra as **temporary settings** for a live preview, reusing the existing `PenumbraService.SetMod` path.
- Wires the `GetAvailableModSettings` IPC into `PenumbraService` to enumerate a mod's groups, options and group type.

## Notes

- Best-effort for exotic group types: Imc/Combining render as checkboxes; Complex groups are shown read-only for now (configure them in Penumbra, then use the existing Refresh button to capture).
- Built and smoke-tested in-game against the `testing` branch.

## Files changed

- `Glamourer/Interop/Penumbra/PenumbraService.cs` — wire `GetAvailableModSettings` IPC + `GetAvailableSettings(mod)` accessor.
- `Glamourer/Gui/Tabs/DesignTab/ModAssociationSettingsPopup.cs` *(new)* — the side-window editor.
- `Glamourer/Gui/Tabs/DesignTab/ModAssociationsTab.cs` — row button + wiring.
- `Glamourer/Config/Configuration.cs` — `KeepModSettingsAttached` option.
- `Glamourer/Gui/Tabs/SettingsTab/SettingsTab.cs` — settings checkbox for the new option.
