### PR TITLE
Fix ActorState initialization in ReapplyState

### DIFF
--- a/Glamourer/Api/StateApi.cs
+++ b/Glamourer/Api/StateApi.cs
@@ -127,11 +127,8 @@ public sealed class StateApi : IGlamourerApiState, IApiService, IDisposable
     public GlamourerApiEc ReapplyState(int objectIndex, uint key, ApplyFlag flags)
     {
         var args = ApiHelpers.Args("Index", objectIndex, "Key", key, "Flags", flags);
-        if (_helpers.FindExistingState(objectIndex, out var state) is not GlamourerApiEc.Success)
+        if (_helpers.FindState(objectIndex) is not { } state)
             return ApiHelpers.Return(GlamourerApiEc.ActorNotFound, args);
-
-        if (state is null)
-            return ApiHelpers.Return(GlamourerApiEc.NothingDone, args);
 
         if (!state.CanUnlock(key))
             return ApiHelpers.Return(GlamourerApiEc.InvalidKey, args);


### PR DESCRIPTION
When initially implemented, `ReapplyState` used `FindExistingStates` instead of `FindStates` to locate the `ActorState` (for both `objectIndex` and `playerName` lookups). This caused it to use `TryGetValue` rather than `GetOrCreate`, preventing it from initializing an `ActorState` in the `StateManager` if one didn't already exist.

This update changes `ReapplyState` to use `FindStates` for `objectIndex` lookups. This brings its behavior in line with `GetState`, `ApplyState`, and the ActorPanel's Reapply button, all of which properly trigger a `GetOrCreate` to ensure the state initializes correctly.