### PR TITLE
Add the remaining dyeable scalars to Advanced Dyes

### DIFF
--- a/Glamourer/Gui/Materials/AdvancedDyePopup.cs
+++ b/Glamourer/Gui/Materials/AdvancedDyePopup.cs
@@ -9,6 +9,7 @@ using ImSharp;
 using Luna;
 using Penumbra.GameData.Enums;
 using Penumbra.GameData.Files.MaterialStructs;
+using Penumbra.GameData.Gui;
 using Penumbra.GameData.Interop;
 using Penumbra.String;
 using Notification = Luna.Notification;
@@ -19,7 +20,8 @@ public sealed unsafe class AdvancedDyePopup(
     Configuration config,
     StateManager stateManager,
     LiveColorTablePreviewer preview,
-    DirectXService directX) : IService
+    DirectXService directX,
+    TextureArraySlicePickers textureArraySlicePickers) : IService
 {
     public static readonly AwesomeIcon Palette = FontAwesomeIcon.Palette;
 
@@ -34,6 +36,7 @@ public sealed unsafe class AdvancedDyePopup(
     private const int  RowsPerPage = 16;
     private       int  _rowOffset;
     private       bool _editSheen;
+    private       bool _editExtra;
 
     private bool ShouldBeDrawn()
     {
@@ -183,7 +186,7 @@ public sealed unsafe class AdvancedDyePopup(
     {
         var layerButtonWidth = _mode is ColorRow.Mode.Dawntrail ? Im.Font.Mono.GetCharacterAdvance(' ') * 5 + Im.Style.FramePadding.X * 2 : 0;
         var buttonWidth =
-            (Im.ContentRegion.Available.X - (_mode is ColorRow.Mode.Dawntrail ? layerButtonWidth * 2 + Im.Style.ItemSpacing.X : 0)) / 2;
+            (Im.ContentRegion.Available.X - (_mode is ColorRow.Mode.Dawntrail ? layerButtonWidth * 3 + Im.Style.ItemSpacing.X : 0)) / 2;
         var       buttonSize = new Vector2(buttonWidth, 0);
         using var font       = Im.Font.PushMono();
         using var hoverColor = ImGuiColor.ButtonHovered.Push(Im.Style[ImGuiColor.TabHovered]);
@@ -206,16 +209,35 @@ public sealed unsafe class AdvancedDyePopup(
 
             buttonSize = new Vector2(layerButtonWidth, 0);
 
-            hoverColor.Push(ImGuiColor.Button, Im.Style[!_editSheen ? ImGuiColor.TabSelected : ImGuiColor.Tab]);
+            hoverColor.Push(ImGuiColor.Button, Im.Style[_editSheen || _editExtra ? ImGuiColor.Tab : ImGuiColor.TabSelected]);
             if (ImEx.ButtonCorners("Base"u8, buttonSize, ButtonFlags.MouseButtonLeft, Corners.Left))
+            {
                 _editSheen = false;
+                _editExtra = false;
+            }
+
             hoverColor.Pop();
 
             Im.Line.NoSpacing();
 
             hoverColor.Push(ImGuiColor.Button, Im.Style[_editSheen ? ImGuiColor.TabSelected : ImGuiColor.Tab]);
-            if (ImEx.ButtonCorners("Sheen"u8, buttonSize, ButtonFlags.MouseButtonLeft, Corners.Right))
+            if (ImEx.ButtonCorners("Sheen"u8, buttonSize, ButtonFlags.MouseButtonLeft, Corners.None))
+            {
                 _editSheen = true;
+                _editExtra = false;
+            }
+
+            hoverColor.Pop();
+
+            Im.Line.NoSpacing();
+
+            hoverColor.Push(ImGuiColor.Button, Im.Style[_editExtra ? ImGuiColor.TabSelected : ImGuiColor.Tab]);
+            if (ImEx.ButtonCorners("Extra"u8, buttonSize, ButtonFlags.MouseButtonLeft, Corners.Right))
+            {
+                _editSheen = false;
+                _editExtra = true;
+            }
+
             hoverColor.Pop();
         }
     }
@@ -475,6 +497,40 @@ public sealed unsafe class AdvancedDyePopup(
             applied |= DragSheenRoughness(ref value.Model.SheenAperture, false);
             Im.Tooltip.OnHover("Change the sheen roughness for this row."u8);
         }
+        else if (_mode is ColorRow.Mode.Dawntrail && _editExtra)
+        {
+            // This layout has 4 items and three spacings: 4*w + 3*sp = 200*sc + 1*sp.
+            var allItemsWidth = 200 * Im.Style.GlobalScale - 2 * spacing.X;
+            var itemWidth     = MathF.Floor(allItemsWidth / 4);
+
+            Im.Item.SetNextWidth(itemWidth);
+            applied |= DragExposure(ref value.Model.Exposure, false);
+            Im.Tooltip.OnHover("Change the exposure value for this row."u8);
+
+            Im.Line.Same(0, spacing.X);
+
+            Im.Item.SetNextWidth(itemWidth);
+            using (Im.Style.Push(ImStyleSingle.Alpha, 0.5f * Im.Style.Alpha, (index.RowIndex & 1) is not 0))
+            {
+                applied |= DragAnisotropy(ref value.Model.Anisotropy, false);
+            }
+
+            Im.Tooltip.OnHover((index.RowIndex & 1) is 0
+                ? "Change the anisotropy degree for this row."u8
+                : "Change the anisotropy degree for this row.\nThis has no effect on B rows, unless using a shader mod."u8);
+
+            Im.Line.Same(0, spacing.X);
+
+            Im.Item.SetNextWidth(itemWidth);
+            applied |= InputSphereMapIndex(textureArraySlicePickers, "Change the sphere map for this row."u8, ref value.Model.SphereMapIndex,
+                false);
+
+            Im.Line.Same(0, spacing.X);
+
+            Im.Item.SetNextWidth(allItemsWidth - itemWidth * 3);
+            applied |= DragSphereMapMask(ref value.Model.SphereMapMask, false);
+            Im.Tooltip.OnHover("Change the sphere map intensity for this row."u8);
+        }
         else
         {
             Im.Item.SetNextWidthScaled(100);
@@ -659,6 +715,69 @@ public sealed unsafe class AdvancedDyePopup(
             return false;
 
         value = tmp2;
+        return true;
+    }
+
+    private static readonly float ExposureMax          = MathF.Log2((float)Half.MaxValue) * 0.5f;
+    private static readonly float ExposureMinThreshold = -MathF.Ceiling(ExposureMax * 10.0f) * 0.1f;
+    private static readonly float ExposureMinInfDummy  = ExposureMinThreshold - 0.025f;
+
+    public static bool DragExposure(ref float value, bool canUnset)
+    {
+        var tmp = value is 0.0f ? ExposureMinInfDummy : MathF.Log2(float.IsNaN(value) ? ColorRow.DefaultExposure : value) * 0.5f;
+        if (!Im.Drag("##Exposure"u8, ref tmp, float.IsNaN(value) ? $"{char.EmDash} X" : value is 0.0f ? "-∞ X"u8 : "%.1f X"u8,
+                ExposureMinInfDummy, ExposureMax, 0.025f, SliderFlags.AlwaysClamp))
+            return UnsetBehavior(ref value, canUnset);
+
+        var tmp2 = tmp < ExposureMinThreshold ? 0.0f : MathF.Pow(2.0f, Math.Clamp(tmp, -ExposureMax, ExposureMax) * 2.0f);
+        if (tmp2 == value)
+            return false;
+
+        value = tmp2;
+        return true;
+    }
+
+    public static bool DragAnisotropy(ref float value, bool canUnset)
+    {
+        var tmp = float.IsNaN(value) ? ColorRow.DefaultAnisotropy : value;
+        if (!Im.Drag("##Anisotropy"u8, ref tmp, float.IsNaN(value) ? $"{char.EmDash} A" : "%.1f A"u8, 0f, (float)Half.MaxValue, 0.025f,
+                SliderFlags.AlwaysClamp))
+            return UnsetBehavior(ref value, canUnset);
+
+        var tmp2 = Math.Clamp(tmp, 0f, (float)Half.MaxValue);
+        if (tmp2 == value)
+            return false;
+
+        value = tmp2;
+        return true;
+    }
+
+    public static bool DragSphereMapMask(ref float value, bool canUnset)
+    {
+        var tmp = (float.IsNaN(value) ? ColorRow.DefaultSphereMapMask : value) * 100f;
+        if (!Im.Drag("##SphereMapMask"u8, ref tmp, float.IsNaN(value) ? $"{char.EmDash} S" : "%.0f%% S"u8, 0f, 100f * (float)Half.MaxValue, 0.25f,
+                SliderFlags.AlwaysClamp))
+            return UnsetBehavior(ref value, canUnset);
+
+        var tmp2 = Math.Clamp(tmp, 0f, 100f * (float)Half.MaxValue) / 100f;
+        if (tmp2 == value)
+            return false;
+
+        value = tmp2;
+        return true;
+    }
+
+    public static bool InputSphereMapIndex(TextureArraySlicePickers textureArraySlicePickers, ReadOnlySpan<byte> description, ref ushort value,
+        bool canUnset)
+        => textureArraySlicePickers.DrawSphereMapIndexPicker("##SphereMapIndex"u8, description, ref value, true)
+         || UnsetBehavior(ref value, canUnset);
+
+    private static bool UnsetBehavior(ref ushort value, bool canUnset)
+    {
+        if (!(canUnset && Im.Item.RightClicked() && Im.Io.KeyControl))
+            return false;
+
+        value = ushort.MaxValue;
         return true;
     }
 

--- a/Glamourer/Gui/Materials/MaterialDrawer.cs
+++ b/Glamourer/Gui/Materials/MaterialDrawer.cs
@@ -5,14 +5,17 @@ using ImSharp;
 using Luna;
 using Penumbra.GameData.Enums;
 using Penumbra.GameData.Files.MaterialStructs;
+using Penumbra.GameData.Gui;
 
 namespace Glamourer.Gui.Materials;
 
-public unsafe class MaterialDrawer(DesignManager designManager, Configuration config) : IService
+public unsafe class MaterialDrawer(DesignManager designManager, Configuration config, TextureArraySlicePickers textureArraySlicePickers)
+    : IService
 {
     public const float SliderWidth      = 90;
     public const float ModeWidth        = 45;
-    public const float SheenSliderWidth = (2 * SliderWidth + ModeWidth) / 3;
+    public const float RowBaseWidth     = 2 * SliderWidth + ModeWidth;
+    public const float SheenSliderWidth = RowBaseWidth / 3;
 
     private int                _newMaterialIdx;
     private int                _newRowIdx;
@@ -38,7 +41,7 @@ public unsafe class MaterialDrawer(DesignManager designManager, Configuration co
         Im.Dummy(0);
         Im.Separator();
         Im.Dummy(0);
-        if (available > 2.6f * colorWidth)
+        if (available > 3.25f * colorWidth)
             DrawSingleRow(design);
         else
             DrawMultipleRow(design);
@@ -364,6 +367,38 @@ public unsafe class MaterialDrawer(DesignManager designManager, Configuration co
         Im.Item.SetNextWidthScaled(SheenSliderWidth);
         applied |= AdvancedDyePopup.DragSheenRoughness(ref tmp.SheenAperture, true);
         Im.Tooltip.OnHover("Change the sheen roughness for this row.\nControl and Right-Click to unset."u8);
+
+        if (!compact)
+            Im.Dummy(_buttonSize with { X = _buttonSize.X * 3 + _spacing * 2 });
+
+        var allItemsWidth = RowBaseWidth - Im.Style.ItemInnerSpacing.X;
+        var itemWidth     = MathF.Floor(allItemsWidth / 4);
+
+        Im.Line.SameInner();
+        Im.Item.SetNextWidth(itemWidth);
+        applied |= AdvancedDyePopup.DragExposure(ref tmp.Exposure, true);
+        Im.Tooltip.OnHover("Change the exposure value for this row.\nControl and Right-Click to unset."u8);
+
+        Im.Line.SameInner();
+        Im.Item.SetNextWidth(itemWidth);
+        using (Im.Style.Push(ImStyleSingle.Alpha, 0.5f * Im.Style.Alpha, (index.RowIndex & 1) is not 0))
+        {
+            applied |= AdvancedDyePopup.DragAnisotropy(ref tmp.Anisotropy, true);
+        }
+
+        Im.Tooltip.OnHover((index.RowIndex & 1) is 0
+            ? "Change the anisotropy degree for this row.\nControl and Right-Click to unset."u8
+            : "Change the anisotropy degree for this row.\nThis has no effect on B rows, unless using a shader mod.\nControl and Right-Click to unset."u8);
+
+        Im.Line.SameInner();
+        Im.Item.SetNextWidth(itemWidth);
+        applied |= AdvancedDyePopup.InputSphereMapIndex(textureArraySlicePickers,
+            "Change the sphere map for this row.\nControl and Right-Click to unset."u8, ref tmp.SphereMapIndex, true);
+
+        Im.Line.SameInner();
+        Im.Item.SetNextWidth(allItemsWidth - itemWidth * 3);
+        applied |= AdvancedDyePopup.DragSphereMapMask(ref tmp.SphereMapMask, true);
+        Im.Tooltip.OnHover("Change the sphere map intensity for this row.\nControl and Right-Click to unset."u8);
 
         if (applied)
             designManager.ChangeMaterialValue(design, index, tmp);

--- a/Glamourer/Interop/Material/MaterialValueManager.cs
+++ b/Glamourer/Interop/Material/MaterialValueManager.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Penumbra.GameData.Enums;
 using Penumbra.GameData.Files.MaterialStructs;
+using Penumbra.GameData.Files.StainMapStructs;
 using Penumbra.GameData.Structs;
 using JsonSerializer = Newtonsoft.Json.JsonSerializer;
 
@@ -26,7 +27,11 @@ public struct ColorRow(
     float metalness,
     float sheen,
     float sheenTint,
-    float sheenAperture)
+    float sheenAperture,
+    float exposure,
+    float anisotropy,
+    float sphereMapMask,
+    ushort sphereMapIndex)
 {
     public enum Mode
     {
@@ -34,16 +39,20 @@ public struct ColorRow(
         Dawntrail,
     }
 
-    public const float DefaultSpecularStrength = 1f;
-    public const float DefaultGlossStrength    = 20f;
-    public const float DefaultRoughness        = 0.5f;
-    public const float DefaultMetalness        = 0f;
-    public const float DefaultSheen            = 0.1f;
-    public const float DefaultSheenTint        = 0.2f;
-    public const float DefaultSheenAperture    = 5f;
+    public const float  DefaultSpecularStrength = 1f;
+    public const float  DefaultGlossStrength    = 20f;
+    public const float  DefaultRoughness        = 0.5f;
+    public const float  DefaultMetalness        = 0f;
+    public const float  DefaultSheen            = 0.1f;
+    public const float  DefaultSheenTint        = 0.2f;
+    public const float  DefaultSheenAperture    = 5f;
+    public const float  DefaultExposure         = 1f;
+    public const float  DefaultAnisotropy       = 0f;
+    public const float  DefaultSphereMapMask    = 0f;
+    public const ushort DefaultSphereMapIndex   = 0;
 
     public static readonly ColorRow Empty = new(Vector3.Zero, Vector3.Zero, Vector3.Zero, float.NaN, float.NaN, float.NaN, float.NaN, float.NaN,
-        float.NaN, float.NaN);
+        float.NaN, float.NaN, float.NaN, float.NaN, float.NaN, ushort.MaxValue);
 
     public Vector3 Diffuse          = diffuse;
     public Vector3 Specular         = specular;
@@ -55,17 +64,33 @@ public struct ColorRow(
     public float   Sheen            = sheen;
     public float   SheenTint        = sheenTint;
     public float   SheenAperture    = sheenAperture;
+    public float   Exposure         = exposure;
+    public float   Anisotropy       = anisotropy;
+    public float   SphereMapMask    = sphereMapMask;
+    public ushort  SphereMapIndex   = sphereMapIndex;
 
     public static ColorRow From(in ColorTableRow row, Mode mode)
         => mode switch
         {
             Mode.Legacy => new ColorRow(Root((Vector3)row.DiffuseColor), Root((Vector3)row.SpecularColor), Root((Vector3)row.EmissiveColor),
-                (float)row.LegacySpecularStrength(), (float)row.LegacyGloss(), float.NaN, float.NaN, float.NaN, float.NaN, float.NaN),
+                (float)row.LegacySpecularStrength(), (float)row.LegacyGloss(), float.NaN, float.NaN, float.NaN, float.NaN, float.NaN, float.NaN,
+                float.NaN, float.NaN, ushort.MaxValue),
             Mode.Dawntrail => new ColorRow(Root((Vector3)row.DiffuseColor), Root((Vector3)row.SpecularColor), Root((Vector3)row.EmissiveColor),
                 float.NaN, float.NaN, (float)row.DawntrailRoughness(), (float)row.DawntrailMetalness(), (float)row.DawntrailSheen(),
-                (float)row.DawntrailSheenTint(), (float)row.DawntrailSheenAperture()),
+                (float)row.DawntrailSheenTint(), (float)row.DawntrailSheenAperture(), (float)row.DawntrailExposure(),
+                (float)row.DawntrailAnisotropy(), (float)row.DawntrailSphereMapMask(), (ushort)row.DawntrailSphereMapIndex()),
             _ => throw new NotImplementedException(),
         };
+
+    public static ColorRow From(in LegacyDyePack row)
+        => new ColorRow(Root((Vector3)row.DiffuseColor), Root((Vector3)row.SpecularColor), Root((Vector3)row.EmissiveColor),
+            (float)row.SpecularMask, (float)row.Shininess, float.NaN, float.NaN, float.NaN, float.NaN, float.NaN, float.NaN, float.NaN,
+            float.NaN, ushort.MaxValue);
+
+    public static ColorRow From(in DyePack row)
+        => new ColorRow(Root((Vector3)row.DiffuseColor), Root((Vector3)row.SpecularColor), Root((Vector3)row.EmissiveColor),
+            float.NaN, float.NaN, (float)row.Roughness, (float)row.Metalness, (float)row.SheenRate, (float)row.SheenTintRate,
+            (float)row.SheenAperture, (float)row.Exposure, (float)row.Anisotropy, (float)row.SphereMapMask, row.SphereMapIndex);
 
     public readonly bool NearEqual(in ColorRow rhs, bool skipEmpty = false)
         => Diffuse.NearEqual(rhs.Diffuse)
@@ -77,7 +102,11 @@ public struct ColorRow(
          && (float.IsNaN(Metalness) ? skipEmpty || float.IsNaN(rhs.Metalness) : Metalness.NearEqual(rhs.Metalness))
          && (float.IsNaN(Sheen) ? skipEmpty || float.IsNaN(rhs.Sheen) : Sheen.NearEqual(rhs.Sheen))
          && (float.IsNaN(SheenAperture) ? skipEmpty || float.IsNaN(rhs.SheenAperture) : SheenAperture.NearEqual(rhs.SheenAperture))
-         && (float.IsNaN(SheenTint) ? skipEmpty || float.IsNaN(rhs.SheenTint) : SheenTint.NearEqual(rhs.SheenTint));
+         && (float.IsNaN(SheenTint) ? skipEmpty || float.IsNaN(rhs.SheenTint) : SheenTint.NearEqual(rhs.SheenTint))
+         && (float.IsNaN(Exposure) ? skipEmpty || float.IsNaN(rhs.Exposure) : Exposure.NearEqual(rhs.Exposure, 1e-6f))
+         && (float.IsNaN(Anisotropy) ? skipEmpty || float.IsNaN(rhs.Anisotropy) : Anisotropy.NearEqual(rhs.Anisotropy))
+         && (float.IsNaN(SphereMapMask) ? skipEmpty || float.IsNaN(rhs.SphereMapMask) : SphereMapMask.NearEqual(rhs.SphereMapMask))
+         && (SphereMapIndex is ushort.MaxValue ? skipEmpty || rhs.SphereMapIndex is ushort.MaxValue : SphereMapIndex == rhs.SphereMapIndex);
 
     private static Vector3 Square(Vector3 value)
         => new(Square(value.X), Square(value.Y), Square(value.Z));
@@ -162,6 +191,30 @@ public struct ColorRow(
                     ret                           = true;
                 }
 
+                if (!float.IsNaN(Exposure) && !((float)row.DawntrailExposure()).NearEqual(Exposure))
+                {
+                    row.DawntrailExposureWrite() = (Half)Exposure;
+                    ret                          = true;
+                }
+
+                if (!float.IsNaN(Anisotropy) && !((float)row.DawntrailAnisotropy()).NearEqual(Anisotropy))
+                {
+                    row.DawntrailAnisotropyWrite() = (Half)Anisotropy;
+                    ret                            = true;
+                }
+
+                if (!float.IsNaN(SphereMapMask) && !((float)row.DawntrailSphereMapMask()).NearEqual(SphereMapMask))
+                {
+                    row.DawntrailSphereMapMaskWrite() = (Half)SphereMapMask;
+                    ret                               = true;
+                }
+
+                if (SphereMapIndex is not ushort.MaxValue && (ushort)row.DawntrailSphereMapIndex() != SphereMapIndex)
+                {
+                    row.DawntrailSphereMapIndexWrite() = (Half)SphereMapIndex;
+                    ret                                = true;
+                }
+
                 break;
             default: throw new NotImplementedException();
         }
@@ -173,7 +226,10 @@ public struct ColorRow(
         => new(Diffuse, Specular, Emissive, float.IsNaN(SpecularStrength) ? previous.SpecularStrength : SpecularStrength,
             float.IsNaN(GlossStrength) ? previous.GlossStrength : GlossStrength, float.IsNaN(Roughness) ? previous.Roughness : Roughness,
             float.IsNaN(Metalness) ? previous.Metalness : Metalness, float.IsNaN(Sheen) ? previous.Sheen : Sheen,
-            float.IsNaN(SheenTint) ? previous.SheenTint : SheenTint, float.IsNaN(SheenAperture) ? previous.SheenAperture : SheenAperture);
+            float.IsNaN(SheenTint) ? previous.SheenTint : SheenTint, float.IsNaN(SheenAperture) ? previous.SheenAperture : SheenAperture,
+            float.IsNaN(Exposure) ? previous.Exposure : Exposure, float.IsNaN(Anisotropy) ? previous.Anisotropy : Anisotropy,
+            float.IsNaN(SphereMapMask) ? previous.SphereMapMask : SphereMapMask,
+            SphereMapIndex is ushort.MaxValue ? previous.SphereMapIndex : SphereMapIndex);
 
     public readonly bool IsPartial(Mode mode)
         => mode switch
@@ -183,17 +239,29 @@ public struct ColorRow(
              || float.IsNaN(Metalness)
              || float.IsNaN(Sheen)
              || float.IsNaN(SheenTint)
-             || float.IsNaN(SheenAperture),
+             || float.IsNaN(SheenAperture)
+             || float.IsNaN(Exposure)
+             || float.IsNaN(Anisotropy)
+             || float.IsNaN(SphereMapMask)
+             || SphereMapIndex is ushort.MaxValue,
             _ => throw new NotImplementedException(),
         };
 
     public readonly Mode GuessMode()
-        => float.IsNaN(Roughness) && float.IsNaN(Metalness) && float.IsNaN(Sheen) && float.IsNaN(SheenTint) && float.IsNaN(SheenAperture)
-            ? Mode.Legacy
-            : Mode.Dawntrail;
+        => float.IsNaN(Roughness)
+         && float.IsNaN(Metalness)
+         && float.IsNaN(Sheen)
+         && float.IsNaN(SheenTint)
+         && float.IsNaN(SheenAperture)
+         && float.IsNaN(Exposure)
+         && float.IsNaN(Anisotropy)
+         && float.IsNaN(SphereMapMask)
+         && SphereMapIndex is ushort.MaxValue
+                ? Mode.Legacy
+                : Mode.Dawntrail;
 
     public override readonly string ToString()
-        => $"[ColorRow Diffuse={Diffuse} Specular={Specular} Emissive={Emissive} SpecularStrength={SpecularStrength} GlossStrength={GlossStrength} Roughness={Roughness} Metalness={Metalness} Sheen={Sheen} SheenTint={SheenTint} SheenAperture={SheenAperture}]";
+        => $"[ColorRow Diffuse={Diffuse} Specular={Specular} Emissive={Emissive} SpecularStrength={SpecularStrength} GlossStrength={GlossStrength} Roughness={Roughness} Metalness={Metalness} Sheen={Sheen} SheenTint={SheenTint} SheenAperture={SheenAperture} Exposure={Exposure} Anisotropy={Anisotropy} SphereMapMask={SphereMapMask} SphereMapIndex={SphereMapIndex}]";
 }
 
 internal static class ColorTableRowExtensions
@@ -205,6 +273,9 @@ internal static class ColorTableRowExtensions
 
         internal Half LegacyGloss()
             => row[3];
+
+        internal Half DawntrailExposure()
+            => row[11];
 
         internal Half DawntrailSheen()
             => row[12];
@@ -220,6 +291,15 @@ internal static class ColorTableRowExtensions
 
         internal Half DawntrailMetalness()
             => row[18];
+
+        internal Half DawntrailAnisotropy()
+            => row[19];
+
+        internal Half DawntrailSphereMapMask()
+            => row[21];
+
+        internal Half DawntrailSphereMapIndex()
+            => row[27];
     }
 
     extension(ref ColorTableRow row)
@@ -229,6 +309,9 @@ internal static class ColorTableRowExtensions
 
         internal ref Half LegacyGlossWrite()
             => ref row[3];
+
+        internal ref Half DawntrailExposureWrite()
+            => ref row[11];
 
         internal ref Half DawntrailSheenWrite()
             => ref row[12];
@@ -244,6 +327,15 @@ internal static class ColorTableRowExtensions
 
         internal ref Half DawntrailMetalnessWrite()
             => ref row[18];
+
+        internal ref Half DawntrailAnisotropyWrite()
+            => ref row[19];
+
+        internal ref Half DawntrailSphereMapMaskWrite()
+            => ref row[21];
+
+        internal ref Half DawntrailSphereMapIndexWrite()
+            => ref row[27];
     }
 }
 
@@ -299,6 +391,11 @@ public struct MaterialValueDesign(ColorRow value, bool enabled, bool revert, Col
         j.WriteIfNotNaN("Sheen"u8,         Value.Sheen);
         j.WriteIfNotNaN("SheenTint"u8,     Value.SheenTint);
         j.WriteIfNotNaN("SheenAperture"u8, Value.SheenAperture);
+        j.WriteIfNotNaN("Exposure"u8,      Value.Exposure);
+        j.WriteIfNotNaN("Anisotropy"u8,    Value.Anisotropy);
+        j.WriteIfNotNaN("SphereMapMask"u8, Value.SphereMapMask);
+        if (Value.SphereMapIndex is not ushort.MaxValue)
+            j.WriteNumber("SphereMapIndex"u8, Value.SphereMapIndex);
         j.WriteEndObject();
     }
 
@@ -358,6 +455,14 @@ public struct MaterialValueDesign(ColorRow value, bool enabled, bool revert, Col
                 value.Value.SheenTint = st;
             else if (j.NumberProperty("SheenAperture"u8, out float sa))
                 value.Value.SheenAperture = Math.Clamp(sa, (float)Half.Epsilon, (float)Half.MaxValue);
+            else if (j.NumberProperty("Exposure"u8, out float ev))
+                value.Value.Exposure = Math.Clamp(ev, 0.0f, (float)Half.MaxValue);
+            else if (j.NumberProperty("Anisotropy"u8, out float an))
+                value.Value.Anisotropy = an;
+            else if (j.NumberProperty("SphereMapMask"u8, out float sm))
+                value.Value.SphereMapMask = sm;
+            else if (j.NumberProperty("SphereMapIndex"u8, out ushort si))
+                value.Value.SphereMapIndex = si;
             else
                 j.Skip();
         }
@@ -443,6 +548,30 @@ public struct MaterialValueDesign(ColorRow value, bool enabled, bool revert, Col
                 writer.WriteValue(value.Value.SheenAperture);
             }
 
+            if (!float.IsNaN(value.Value.Exposure))
+            {
+                writer.WritePropertyName("Exposure");
+                writer.WriteValue(value.Value.Exposure);
+            }
+
+            if (!float.IsNaN(value.Value.Anisotropy))
+            {
+                writer.WritePropertyName("Anisotropy");
+                writer.WriteValue(value.Value.Anisotropy);
+            }
+
+            if (!float.IsNaN(value.Value.SphereMapMask))
+            {
+                writer.WritePropertyName("SphereMapMask");
+                writer.WriteValue(value.Value.SphereMapMask);
+            }
+
+            if (value.Value.SphereMapIndex is not ushort.MaxValue)
+            {
+                writer.WritePropertyName("SphereMapIndex");
+                writer.WriteValue(value.Value.SphereMapIndex);
+            }
+
             writer.WritePropertyName("Enabled");
             writer.WriteValue(value.Enabled);
             writer.WriteEndObject();
@@ -472,6 +601,10 @@ public struct MaterialValueDesign(ColorRow value, bool enabled, bool revert, Col
             existingValue.Value.Sheen            = obj["Sheen"]?.Value<float>() ?? float.NaN;
             existingValue.Value.SheenTint        = obj["SheenTint"]?.Value<float>() ?? float.NaN;
             existingValue.Value.SheenAperture    = obj["SheenAperture"]?.Value<float>() ?? float.NaN;
+            existingValue.Value.Exposure         = obj["Exposure"]?.Value<float>() ?? float.NaN;
+            existingValue.Value.Anisotropy       = obj["Anisotropy"]?.Value<float>() ?? float.NaN;
+            existingValue.Value.SphereMapMask    = obj["SphereMapMask"]?.Value<float>() ?? float.NaN;
+            existingValue.Value.SphereMapIndex   = obj["SphereMapIndex"]?.Value<ushort>() ?? ushort.MaxValue;
             existingValue.Enabled                = obj["Enabled"]?.Value<bool>() ?? false;
             return existingValue;
 

--- a/Glamourer/Interop/Material/MaterialValueManager.cs
+++ b/Glamourer/Interop/Material/MaterialValueManager.cs
@@ -394,8 +394,7 @@ public struct MaterialValueDesign(ColorRow value, bool enabled, bool revert, Col
         j.WriteIfNotNaN("Exposure"u8,      Value.Exposure);
         j.WriteIfNotNaN("Anisotropy"u8,    Value.Anisotropy);
         j.WriteIfNotNaN("SphereMapMask"u8, Value.SphereMapMask);
-        if (Value.SphereMapIndex is not ushort.MaxValue)
-            j.WriteNumber("SphereMapIndex"u8, Value.SphereMapIndex);
+        j.WriteIfNot("SphereMapIndex"u8, Value.SphereMapIndex, ushort.MaxValue);
         j.WriteEndObject();
     }
 


### PR DESCRIPTION
This adds the remaining dyeable scalars (exposure value, anisotropy degree, sphere map index and intensity) to the Advanced Dyes system.

The UI is… not exactly good, but I have no idea how to do it better. (The individual fields work in a way that seem sensible to me, but their packing in the grid feels shoehorned.)