### PR TITLE
Show the mod settings in the associated mods tooltip again

### DIFF
--- a/Glamourer/Gui/Tabs/DesignTab/ModCombo.cs
+++ b/Glamourer/Gui/Tabs/DesignTab/ModCombo.cs
@@ -99,14 +99,13 @@ public sealed class ModCombo(PenumbraSubscriber penumbra, DesignFileSystem fileS
 
     public static void DrawSettingsRight(in SettingPresetData settings)
     {
-        foreach (var setting in settings.Settings)
+        foreach (var (_, data) in settings.Settings)
         {
-            // TODO presets
-            //if (setting.Value.Count is 0)
-            //    Im.Text("<None Enabled>"u8);
-            //else
-            //    foreach (var option in setting.Value)
-            //        Im.Text(option);
+            var enabled = data.Enabled().Select(o => o.Name ?? o.Identifier.ToString()).ToArray();
+            if (enabled.Length is 0)
+                Im.Text("<None Enabled>"u8);
+            else
+                Im.Text(string.Join(", ", enabled));
         }
     }
 


### PR DESCRIPTION
Following the 1.7 update for Glamourer the mod settings no longer show in the tooltip when hovering the button.

Before:
<img width="321" height="248" alt="Screenshot 2026-09-11 084859" src="https://github.com/user-attachments/assets/17ceb044-7bb4-40be-b3d4-012285ce74d9" />

After this change:
<img width="551" height="262" alt="Screenshot 2026-09-11 091133" src="https://github.com/user-attachments/assets/0780b116-187d-408f-b708-9f21c094981f" />


Based on the comments in the code itself, this may have been temporary ahead of a planned overhaul, in which case this can obviously be discarded.